### PR TITLE
cbc: tweak code to help with codegen

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -21,9 +21,9 @@ checksum = "847495c209977a90e8aad588b959d0ca9f5dc228096d29a6bd3defd53f35eaec"
 
 [[package]]
 name = "block-padding"
-version = "0.3.1"
+version = "0.3.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5808df4b2412175c4db3afb115c83d8d0cd26ca4f30a042026cddef8580e526a"
+checksum = "0a90ec2df9600c28a01c56c4784c9207a96d2451833aeceb8cc97e4c9548bb78"
 dependencies = [
  "generic-array",
 ]
@@ -63,9 +63,9 @@ checksum = "baf1de4339761588bc0619e3cbc0120ee582ebb74b53b4efbf79117bd2da40fd"
 
 [[package]]
 name = "cipher"
-version = "0.4.2"
+version = "0.4.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "035bd298db1557b73a277e9c599c5a50e0d2e6ee9dcac78f3f951cb2f7d88d8c"
+checksum = "d1873270f8f7942c191139cb8a40fd228da6c3fd2fc376d7e92d47aa14aeb59e"
 dependencies = [
  "blobby",
  "crypto-common",
@@ -75,9 +75,9 @@ dependencies = [
 
 [[package]]
 name = "cpufeatures"
-version = "0.2.1"
+version = "0.2.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "95059428f66df56b63431fdb4e1947ed2190586af5c5a8a8b71122bdf5a7f469"
+checksum = "59a6001667ab124aebae2a495118e11d30984c3a653e99d86d58971708cf5e4b"
 dependencies = [
  "libc",
 ]
@@ -149,9 +149,9 @@ dependencies = [
 
 [[package]]
 name = "libc"
-version = "0.2.119"
+version = "0.2.121"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1bf2e165bb3457c8e098ea76f3e3bc9db55f87aa90d52d0e6be741470916aaa4"
+checksum = "efaa7b300f3b5fe8eb6bf21ce3895e1751d9665086af2d64b42f19701015ff4f"
 
 [[package]]
 name = "magma"
@@ -194,6 +194,6 @@ checksum = "49874b5167b65d7193b8aba1567f5c7d93d001cafc34600cee003eda787e483f"
 
 [[package]]
 name = "zeroize"
-version = "1.5.2"
+version = "1.5.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7c88870063c39ee00ec285a2f8d6a966e5b6fb2becc4e8dac77ed0d370ed6006"
+checksum = "7eb5728b8afd3f280a869ce1d4c554ffaed35f45c231fc41bfbd0381bef50317"

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -30,7 +30,7 @@ dependencies = [
 
 [[package]]
 name = "cbc"
-version = "0.1.1"
+version = "0.1.2"
 dependencies = [
  "aes",
  "cipher",

--- a/cbc/CHANGELOG.md
+++ b/cbc/CHANGELOG.md
@@ -5,6 +5,12 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## 0.1.2 (2022-03-24)
+### Changed
+- Minor code tweaks to help compiler with codegen ([#15])
+
+[#15]: https://github.com/RustCrypto/block-modes/pull/15
+
 ## 0.1.1 (2022-02-17)
 ### Fixed
 - Minimal versions build ([#9])

--- a/cbc/Cargo.toml
+++ b/cbc/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "cbc"
-version = "0.1.1" # Also update html_root_url in lib.rs when bumping this
+version = "0.1.2" # Also update html_root_url in lib.rs when bumping this
 description = "Cipher Block Chaining (CBC) block cipher mode of operation"
 authors = ["RustCrypto Developers"]
 license = "MIT OR Apache-2.0"

--- a/cbc/src/encrypt.rs
+++ b/cbc/src/encrypt.rs
@@ -173,7 +173,8 @@ where
     fn proc_block(&mut self, mut block: InOut<'_, '_, Block<Self>>) {
         let mut t = block.clone_in();
         xor(&mut t, self.iv);
-        self.backend.proc_block((&t, block.get_out()).into());
-        *self.iv = block.get_out().clone();
+        self.backend.proc_block((&mut t).into());
+        *self.iv = t.clone();
+        *block.get_out() = t;
     }
 }

--- a/cbc/src/lib.rs
+++ b/cbc/src/lib.rs
@@ -90,7 +90,7 @@
 #![doc(
     html_logo_url = "https://raw.githubusercontent.com/RustCrypto/media/26acc39f/logo.svg",
     html_favicon_url = "https://raw.githubusercontent.com/RustCrypto/media/26acc39f/logo.svg",
-    html_root_url = "https://docs.rs/cbc/0.1.1"
+    html_root_url = "https://docs.rs/cbc/0.1.2"
 )]
 #![forbid(unsafe_code)]
 #![cfg_attr(docsrs, feature(doc_cfg))]


### PR DESCRIPTION
The tweaks were developed by inspecting assembly generated for AES-NI backend by the latest Nightly.

Benchmarks results before:
```
test cbc_aes128_decrypt_block  ... bench:      21,150 ns/iter (+/- 4,893) = 774 MB/s
test cbc_aes128_decrypt_blocks ... bench:       5,491 ns/iter (+/- 579) = 2983 MB/s
test cbc_aes128_encrypt_block  ... bench:      17,941 ns/iter (+/- 2,325) = 913 MB/s
test cbc_aes128_encrypt_blocks ... bench:      18,062 ns/iter (+/- 1,679) = 907 MB/s
```
After:
```
test cbc_aes128_decrypt_block  ... bench:      10,109 ns/iter (+/- 564) = 1620 MB/s
test cbc_aes128_decrypt_blocks ... bench:       3,597 ns/iter (+/- 758) = 4554 MB/s
test cbc_aes128_encrypt_block  ... bench:      16,654 ns/iter (+/- 1,828) = 983 MB/s
test cbc_aes128_encrypt_blocks ... bench:      16,478 ns/iter (+/- 695) = 994 MB/s
```