### PR TITLE
pcbc: tweak code to help with codegen

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -173,7 +173,7 @@ dependencies = [
 
 [[package]]
 name = "pcbc"
-version = "0.1.1"
+version = "0.1.2"
 dependencies = [
  "aes",
  "cipher",

--- a/pcbc/CHANGELOG.md
+++ b/pcbc/CHANGELOG.md
@@ -5,6 +5,12 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## 0.1.2 (2022-03-24)
+### Changed
+- Minor code tweaks to help compiler with codegen ([#16])
+
+[#16]: https://github.com/RustCrypto/block-modes/pull/16
+
 ## 0.1.1 (2022-02-17)
 ### Fixed
 - Minimal versions build ([#9])

--- a/pcbc/Cargo.toml
+++ b/pcbc/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "pcbc"
-version = "0.1.1" # Also update html_root_url in lib.rs when bumping this
+version = "0.1.2" # Also update html_root_url in lib.rs when bumping this
 description = "Propagating Cipher Block Chaining (PCBC) block cipher mode of operation"
 authors = ["RustCrypto Developers"]
 license = "MIT OR Apache-2.0"

--- a/pcbc/src/decrypt.rs
+++ b/pcbc/src/decrypt.rs
@@ -171,11 +171,12 @@ where
 {
     #[inline(always)]
     fn proc_block(&mut self, mut block: InOut<'_, '_, Block<Self>>) {
-        let t = self.iv.clone();
-        *self.iv = block.clone_in();
-        self.backend.proc_block(block.reborrow());
-        let res = block.get_out();
-        xor(res, &t);
-        xor(self.iv, res);
+        let mut t1 = block.clone_in();
+        let mut t2 = block.clone_in();
+        self.backend.proc_block((&mut t1).into());
+        xor(&mut t1, &self.iv);
+        xor(&mut t2, &t1);
+        *self.iv = t2;
+        *block.get_out() = t1;
     }
 }

--- a/pcbc/src/encrypt.rs
+++ b/pcbc/src/encrypt.rs
@@ -171,11 +171,12 @@ where
 {
     #[inline(always)]
     fn proc_block(&mut self, mut block: InOut<'_, '_, Block<Self>>) {
-        let mut t = block.clone_in();
-        xor(&mut t, self.iv);
-        *self.iv = block.clone_in();
-        let b = (&t, block.get_out()).into();
-        self.backend.proc_block(b);
-        xor(self.iv, block.get_out());
+        let mut t1 = block.clone_in();
+        let mut t2 = block.clone_in();
+        xor(&mut t1, self.iv);
+        self.backend.proc_block((&mut t1).into());
+        xor(&mut t2, &t1);
+        *block.get_out() = t1;
+        *self.iv = t2;
     }
 }

--- a/pcbc/src/lib.rs
+++ b/pcbc/src/lib.rs
@@ -90,7 +90,7 @@
 #![doc(
     html_logo_url = "https://raw.githubusercontent.com/RustCrypto/media/26acc39f/logo.svg",
     html_favicon_url = "https://raw.githubusercontent.com/RustCrypto/media/26acc39f/logo.svg",
-    html_root_url = "https://docs.rs/pcbc/0.1.1"
+    html_root_url = "https://docs.rs/pcbc/0.1.2"
 )]
 #![forbid(unsafe_code)]
 #![cfg_attr(docsrs, feature(doc_cfg))]


### PR DESCRIPTION
The tweaks were developed by inspecting assembly generated for AES-NI backend by the latest Nightly.

Benchmarks results before:
```
test pcbc_aes128_decrypt_block  ... bench:      23,556 ns/iter (+/- 1,385) = 695 MB/s
test pcbc_aes128_decrypt_blocks ... bench:      24,760 ns/iter (+/- 1,774) = 661 MB/s
test pcbc_aes128_encrypt_block  ... bench:      30,094 ns/iter (+/- 2,308) = 544 MB/s
test pcbc_aes128_encrypt_blocks ... bench:      36,348 ns/iter (+/- 1,779) = 450 MB/s
```
After:
```
test pcbc_aes128_decrypt_block  ... bench:      29,800 ns/iter (+/- 932) = 549 MB/s
test pcbc_aes128_decrypt_blocks ... bench:      19,120 ns/iter (+/- 1,607) = 856 MB/s
test pcbc_aes128_encrypt_block  ... bench:      16,874 ns/iter (+/- 959) = 970 MB/s
test pcbc_aes128_encrypt_blocks ... bench:      16,659 ns/iter (+/- 707) = 983 MB/s
```