### PR TITLE
Add pub to the inner cipher member

### DIFF
--- a/cbc/src/decrypt.rs
+++ b/cbc/src/decrypt.rs
@@ -17,7 +17,7 @@ pub struct Decryptor<C>
 where
     C: BlockDecryptMut + BlockCipher,
 {
-    cipher: C,
+    pub cipher: C,
     iv: Block<C>,
 }
 

--- a/cbc/src/encrypt.rs
+++ b/cbc/src/encrypt.rs
@@ -18,7 +18,7 @@ pub struct Encryptor<C>
 where
     C: BlockEncryptMut + BlockCipher,
 {
-    cipher: C,
+    pub cipher: C,
     iv: Block<C>,
 }
 


### PR DESCRIPTION
To use inner cipher in https://github.com/RustCrypto/traits/pull/1014, we have to make the member`cipher` visible.