### PR TITLE
Detail `seek()` usage

### DIFF
--- a/ctr/src/lib.rs
+++ b/ctr/src/lib.rs
@@ -37,7 +37,7 @@
 //! }
 //! assert_eq!(buf[..], plaintext[..]);
 //!
-//! // CTR mode supports seeking
+//! // CTR mode supports seeking. The parameter is zero-based _bytes_ counter (not _blocks_).
 //! cipher.seek(0u32);
 //!
 //! // encrypt/decrypt from buffer to buffer


### PR DESCRIPTION
It took some effort to understand that `seek` works not by counter blocks (as in [diagram] (from Wikipedia?)), but by bytes of keystream, so I would say it worth mentioning this.

Please, comment if it's better to place this notification upstream to `cipher` crate, or any other place.

[diagram]: https://raw.githubusercontent.com/RustCrypto/media/26acc39f/img/block-modes/ctr_enc.svg