### PR TITLE
cfb-mode: generic mode block size

### DIFF
--- a/cfb-mode/src/buf_decrypt.rs
+++ b/cfb-mode/src/buf_decrypt.rs
@@ -1,0 +1,135 @@
+use cipher::{
+    crypto_common::{InnerUser, IvSizeUser},
+    AlgorithmName, Block, BlockCipher, BlockEncryptMut, InnerIvInit, Iv, Unsigned,
+};
+use core::fmt;
+
+#[cfg(feature = "zeroize")]
+use cipher::zeroize::{Zeroize, ZeroizeOnDrop};
+
+/// CFB mode buffered decryptor.
+#[derive(Clone)]
+pub struct BufDecryptor<C>
+where
+    C: BlockEncryptMut + BlockCipher,
+{
+    cipher: C,
+    iv: Block<C>,
+    pos: usize,
+}
+
+impl<C> BufDecryptor<C>
+where
+    C: BlockEncryptMut + BlockCipher,
+{
+    /// Decrypt a buffer in multiple parts.
+    pub fn decrypt(&mut self, mut data: &mut [u8]) {
+        let bs = C::BlockSize::to_usize();
+        let n = data.len();
+
+        if n < bs - self.pos {
+            xor_set2(data, &mut self.iv[self.pos..self.pos + n]);
+            self.pos += n;
+            return;
+        }
+        let (left, right) = { data }.split_at_mut(bs - self.pos);
+        data = right;
+        let mut iv = self.iv.clone();
+        xor_set2(left, &mut iv[self.pos..]);
+        self.cipher.encrypt_block_mut(&mut iv);
+
+        let mut chunks = data.chunks_exact_mut(bs);
+        for chunk in &mut chunks {
+            xor_set2(chunk, iv.as_mut_slice());
+            self.cipher.encrypt_block_mut(&mut iv);
+        }
+
+        let rem = chunks.into_remainder();
+        xor_set2(rem, iv.as_mut_slice());
+        self.pos = rem.len();
+        self.iv = iv;
+    }
+
+    /// Returns the current state (block and position) of the decryptor.
+    pub fn get_state(&self) -> (&Block<C>, usize) {
+        (&self.iv, self.pos)
+    }
+
+    /// Restore from the given state for resumption.
+    pub fn from_state(cipher: C, iv: &Block<C>, pos: usize) -> Self {
+        Self {
+            cipher,
+            iv: iv.clone(),
+            pos,
+        }
+    }
+}
+
+impl<C> InnerUser for BufDecryptor<C>
+where
+    C: BlockEncryptMut + BlockCipher,
+{
+    type Inner = C;
+}
+
+impl<C> IvSizeUser for BufDecryptor<C>
+where
+    C: BlockEncryptMut + BlockCipher,
+{
+    type IvSize = C::BlockSize;
+}
+
+impl<C> InnerIvInit for BufDecryptor<C>
+where
+    C: BlockEncryptMut + BlockCipher,
+{
+    #[inline]
+    fn inner_iv_init(mut cipher: C, iv: &Iv<Self>) -> Self {
+        let mut iv = iv.clone();
+        cipher.encrypt_block_mut(&mut iv);
+        Self { cipher, iv, pos: 0 }
+    }
+}
+
+impl<C> AlgorithmName for BufDecryptor<C>
+where
+    C: BlockEncryptMut + BlockCipher + AlgorithmName,
+{
+    fn write_alg_name(f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        f.write_str("cfb::BufDecryptor<")?;
+        <C as AlgorithmName>::write_alg_name(f)?;
+        f.write_str(">")
+    }
+}
+
+impl<C> fmt::Debug for BufDecryptor<C>
+where
+    C: BlockEncryptMut + BlockCipher + AlgorithmName,
+{
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        f.write_str("cfb::BufDecryptor<")?;
+        <C as AlgorithmName>::write_alg_name(f)?;
+        f.write_str("> { ... }")
+    }
+}
+
+#[cfg(feature = "zeroize")]
+#[cfg_attr(docsrs, doc(cfg(feature = "zeroize")))]
+impl<C: BlockEncryptMut + BlockCipher> Drop for BufDecryptor<C> {
+    fn drop(&mut self) {
+        self.iv.zeroize();
+    }
+}
+
+#[cfg(feature = "zeroize")]
+#[cfg_attr(docsrs, doc(cfg(feature = "zeroize")))]
+impl<C: BlockEncryptMut + BlockCipher + ZeroizeOnDrop> ZeroizeOnDrop for BufDecryptor<C> {}
+
+#[inline(always)]
+fn xor_set2(buf1: &mut [u8], buf2: &mut [u8]) {
+    for (a, b) in buf1.iter_mut().zip(buf2) {
+        let t = *a;
+        *a ^= *b;
+        *b = t;
+    }
+}

--- a/cfb-mode/src/buf_encrypt.rs
+++ b/cfb-mode/src/buf_encrypt.rs
@@ -1,0 +1,136 @@
+use cipher::{
+    crypto_common::{InnerUser, IvSizeUser},
+    AlgorithmName, Block, BlockCipher, BlockEncryptMut, InnerIvInit, Iv, Unsigned,
+};
+use core::fmt;
+
+#[cfg(feature = "zeroize")]
+use cipher::zeroize::{Zeroize, ZeroizeOnDrop};
+
+/// CFB mode buffered encryptor.
+#[derive(Clone)]
+pub struct BufEncryptor<C>
+where
+    C: BlockEncryptMut + BlockCipher,
+{
+    cipher: C,
+    iv: Block<C>,
+    pos: usize,
+}
+
+impl<C> BufEncryptor<C>
+where
+    C: BlockEncryptMut + BlockCipher,
+{
+    /// Encrypt a buffer in multiple parts.
+    pub fn encrypt(&mut self, mut data: &mut [u8]) {
+        let bs = C::BlockSize::USIZE;
+        let n = data.len();
+
+        if n < bs - self.pos {
+            xor_set1(data, &mut self.iv[self.pos..self.pos + n]);
+            self.pos += n;
+            return;
+        }
+
+        let (left, right) = { data }.split_at_mut(bs - self.pos);
+        data = right;
+        let mut iv = self.iv.clone();
+        xor_set1(left, &mut iv[self.pos..]);
+        self.cipher.encrypt_block_mut(&mut iv);
+
+        let mut chunks = data.chunks_exact_mut(bs);
+        for chunk in &mut chunks {
+            xor_set1(chunk, iv.as_mut_slice());
+            self.cipher.encrypt_block_mut(&mut iv);
+        }
+
+        let rem = chunks.into_remainder();
+        xor_set1(rem, iv.as_mut_slice());
+        self.pos = rem.len();
+        self.iv = iv;
+    }
+
+    /// Returns the current state (block and position) of the decryptor.
+    pub fn get_state(&self) -> (&Block<C>, usize) {
+        (&self.iv, self.pos)
+    }
+
+    /// Restore from the given state for resumption.
+    pub fn from_state(cipher: C, iv: &Block<C>, pos: usize) -> Self {
+        Self {
+            cipher,
+            iv: iv.clone(),
+            pos,
+        }
+    }
+}
+
+impl<C> InnerUser for BufEncryptor<C>
+where
+    C: BlockEncryptMut + BlockCipher,
+{
+    type Inner = C;
+}
+
+impl<C> IvSizeUser for BufEncryptor<C>
+where
+    C: BlockEncryptMut + BlockCipher,
+{
+    type IvSize = C::BlockSize;
+}
+
+impl<C> InnerIvInit for BufEncryptor<C>
+where
+    C: BlockEncryptMut + BlockCipher,
+{
+    #[inline]
+    fn inner_iv_init(mut cipher: C, iv: &Iv<Self>) -> Self {
+        let mut iv = iv.clone();
+        cipher.encrypt_block_mut(&mut iv);
+        Self { cipher, iv, pos: 0 }
+    }
+}
+
+impl<C> AlgorithmName for BufEncryptor<C>
+where
+    C: BlockEncryptMut + BlockCipher + AlgorithmName,
+{
+    fn write_alg_name(f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        f.write_str("cfb::BufEncryptor<")?;
+        <C as AlgorithmName>::write_alg_name(f)?;
+        f.write_str(">")
+    }
+}
+
+impl<C> fmt::Debug for BufEncryptor<C>
+where
+    C: BlockEncryptMut + BlockCipher + AlgorithmName,
+{
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        f.write_str("cfb::BufEncryptor<")?;
+        <C as AlgorithmName>::write_alg_name(f)?;
+        f.write_str("> { ... }")
+    }
+}
+
+#[cfg(feature = "zeroize")]
+#[cfg_attr(docsrs, doc(cfg(feature = "zeroize")))]
+impl<C: BlockEncryptMut + BlockCipher> Drop for BufEncryptor<C> {
+    fn drop(&mut self) {
+        self.iv.zeroize();
+    }
+}
+
+#[cfg(feature = "zeroize")]
+#[cfg_attr(docsrs, doc(cfg(feature = "zeroize")))]
+impl<C: BlockEncryptMut + BlockCipher + ZeroizeOnDrop> ZeroizeOnDrop for BufEncryptor<C> {}
+
+#[inline(always)]
+fn xor_set1(buf1: &mut [u8], buf2: &mut [u8]) {
+    for (a, b) in buf1.iter_mut().zip(buf2) {
+        let t = *a ^ *b;
+        *a = t;
+        *b = t;
+    }
+}

--- a/cfb-mode/src/decrypt.rs
+++ b/cfb-mode/src/decrypt.rs
@@ -1,158 +1,95 @@
 use cipher::{
+    consts::U1,
     crypto_common::{InnerUser, IvSizeUser},
     generic_array::{ArrayLength, GenericArray},
     inout::InOut,
     AlgorithmName, AsyncStreamCipher, Block, BlockBackend, BlockCipher, BlockClosure, BlockDecrypt,
-    BlockDecryptMut, BlockEncryptMut, BlockSizeUser, InnerIvInit, Iv, IvState, ParBlocks,
-    ParBlocksSizeUser, Unsigned,
+    BlockDecryptMut, BlockEncryptMut, BlockSizeUser, InnerIvInit, Iv, IvState, ParBlocksSizeUser,
 };
-use core::fmt;
+use core::{fmt, marker::PhantomData};
 
 #[cfg(feature = "zeroize")]
 use cipher::zeroize::{Zeroize, ZeroizeOnDrop};
 
 /// CFB mode decryptor.
 #[derive(Clone)]
-pub struct Decryptor<C>
+pub struct Decryptor<C, MBS = <C as BlockSizeUser>::BlockSize>
 where
     C: BlockEncryptMut + BlockCipher,
+    MBS: ArrayLength<u8>,
 {
     cipher: C,
     iv: Block<C>,
+    _pd: PhantomData<MBS>,
 }
 
-/// CFB mode buffered decryptor.
-#[derive(Clone)]
-pub struct BufDecryptor<C>
+impl<C, MBS> BlockSizeUser for Decryptor<C, MBS>
 where
     C: BlockEncryptMut + BlockCipher,
+    MBS: ArrayLength<u8>,
 {
-    cipher: C,
-    iv: Block<C>,
-    pos: usize,
+    type BlockSize = MBS;
 }
 
-impl<C> BufDecryptor<C>
+impl<C, MBS> BlockDecryptMut for Decryptor<C, MBS>
 where
     C: BlockEncryptMut + BlockCipher,
-{
-    /// Decrypt a buffer in multiple parts.
-    pub fn decrypt(&mut self, mut data: &mut [u8]) {
-        let bs = C::BlockSize::to_usize();
-        let n = data.len();
-
-        if n < bs - self.pos {
-            xor_set2(data, &mut self.iv[self.pos..self.pos + n]);
-            self.pos += n;
-            return;
-        }
-        let (left, right) = { data }.split_at_mut(bs - self.pos);
-        data = right;
-        let mut iv = self.iv.clone();
-        xor_set2(left, &mut iv[self.pos..]);
-        self.cipher.encrypt_block_mut(&mut iv);
-
-        let mut chunks = data.chunks_exact_mut(bs);
-        for chunk in &mut chunks {
-            xor_set2(chunk, iv.as_mut_slice());
-            self.cipher.encrypt_block_mut(&mut iv);
-        }
-
-        let rem = chunks.into_remainder();
-        xor_set2(rem, iv.as_mut_slice());
-        self.pos = rem.len();
-        self.iv = iv;
-    }
-
-    /// Returns the current state (block and position) of the decryptor.
-    pub fn get_state(&self) -> (&Block<C>, usize) {
-        (&self.iv, self.pos)
-    }
-
-    /// Restore from the given state for resumption.
-    pub fn from_state(cipher: C, iv: &Block<C>, pos: usize) -> Self {
-        Self {
-            cipher,
-            iv: iv.clone(),
-            pos,
-        }
-    }
-}
-
-impl<C> BlockSizeUser for Decryptor<C>
-where
-    C: BlockEncryptMut + BlockCipher,
-{
-    type BlockSize = C::BlockSize;
-}
-
-impl<C> BlockDecryptMut for Decryptor<C>
-where
-    C: BlockEncryptMut + BlockCipher,
+    MBS: ArrayLength<u8>,
 {
     fn decrypt_with_backend_mut(&mut self, f: impl BlockClosure<BlockSize = Self::BlockSize>) {
-        let Self { cipher, iv } = self;
-        cipher.encrypt_with_backend_mut(Closure { iv, f })
+        let Self { cipher, iv, _pd } = self;
+        cipher.encrypt_with_backend_mut(Closure {
+            iv,
+            f,
+            _pd: _pd.clone(),
+        })
     }
 }
 
-impl<C> AsyncStreamCipher for Decryptor<C> where C: BlockEncryptMut + BlockCipher {}
-
-impl<C> InnerUser for Decryptor<C>
+impl<C, MBS> AsyncStreamCipher for Decryptor<C, MBS>
 where
     C: BlockEncryptMut + BlockCipher,
+    MBS: ArrayLength<u8>,
+{
+}
+
+impl<C, MBS> InnerUser for Decryptor<C, MBS>
+where
+    C: BlockEncryptMut + BlockCipher,
+    MBS: ArrayLength<u8>,
 {
     type Inner = C;
 }
 
-impl<C> InnerUser for BufDecryptor<C>
+impl<C, MBS> IvSizeUser for Decryptor<C, MBS>
 where
     C: BlockEncryptMut + BlockCipher,
-{
-    type Inner = C;
-}
-
-impl<C> IvSizeUser for Decryptor<C>
-where
-    C: BlockEncryptMut + BlockCipher,
+    MBS: ArrayLength<u8>,
 {
     type IvSize = C::BlockSize;
 }
 
-impl<C> IvSizeUser for BufDecryptor<C>
+impl<C, MBS> InnerIvInit for Decryptor<C, MBS>
 where
     C: BlockEncryptMut + BlockCipher,
-{
-    type IvSize = C::BlockSize;
-}
-
-impl<C> InnerIvInit for Decryptor<C>
-where
-    C: BlockEncryptMut + BlockCipher,
+    MBS: ArrayLength<u8>,
 {
     #[inline]
     fn inner_iv_init(mut cipher: C, iv: &Iv<Self>) -> Self {
         let mut iv = iv.clone();
         cipher.encrypt_block_mut(&mut iv);
-        Self { cipher, iv }
+        Self {
+            cipher,
+            iv,
+            _pd: PhantomData,
+        }
     }
 }
 
-impl<C> InnerIvInit for BufDecryptor<C>
-where
-    C: BlockEncryptMut + BlockCipher,
-{
-    #[inline]
-    fn inner_iv_init(mut cipher: C, iv: &Iv<Self>) -> Self {
-        let mut iv = iv.clone();
-        cipher.encrypt_block_mut(&mut iv);
-        Self { cipher, iv, pos: 0 }
-    }
-}
-
-impl<C> IvState for Decryptor<C>
+impl<C, MBS> IvState for Decryptor<C, MBS>
 where
     C: BlockEncryptMut + BlockDecrypt + BlockCipher,
+    MBS: ArrayLength<u8>,
 {
     #[inline]
     fn iv_state(&self) -> Iv<Self> {
@@ -162,9 +99,10 @@ where
     }
 }
 
-impl<C> AlgorithmName for Decryptor<C>
+impl<C, MBS> AlgorithmName for Decryptor<C, MBS>
 where
     C: BlockEncryptMut + BlockCipher + AlgorithmName,
+    MBS: ArrayLength<u8>,
 {
     fn write_alg_name(f: &mut fmt::Formatter<'_>) -> fmt::Result {
         f.write_str("cfb::Decryptor<")?;
@@ -173,20 +111,10 @@ where
     }
 }
 
-impl<C> AlgorithmName for BufDecryptor<C>
+impl<C, MBS> fmt::Debug for Decryptor<C, MBS>
 where
     C: BlockEncryptMut + BlockCipher + AlgorithmName,
-{
-    fn write_alg_name(f: &mut fmt::Formatter<'_>) -> fmt::Result {
-        f.write_str("cfb::BufDecryptor<")?;
-        <C as AlgorithmName>::write_alg_name(f)?;
-        f.write_str(">")
-    }
-}
-
-impl<C> fmt::Debug for Decryptor<C>
-where
-    C: BlockEncryptMut + BlockCipher + AlgorithmName,
+    MBS: ArrayLength<u8>,
 {
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
         f.write_str("cfb::Decryptor<")?;
@@ -195,20 +123,13 @@ where
     }
 }
 
-impl<C> fmt::Debug for BufDecryptor<C>
-where
-    C: BlockEncryptMut + BlockCipher + AlgorithmName,
-{
-    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
-        f.write_str("cfb::BufDecryptor<")?;
-        <C as AlgorithmName>::write_alg_name(f)?;
-        f.write_str("> { ... }")
-    }
-}
-
 #[cfg(feature = "zeroize")]
 #[cfg_attr(docsrs, doc(cfg(feature = "zeroize")))]
-impl<C: BlockEncryptMut + BlockCipher> Drop for Decryptor<C> {
+impl<C, MBS> Drop for Decryptor<C, MBS>
+where
+    C: BlockEncryptMut + BlockCipher,
+    MBS: ArrayLength<u8>,
+{
     fn drop(&mut self) {
         self.iv.zeroize();
     }
@@ -216,107 +137,123 @@ impl<C: BlockEncryptMut + BlockCipher> Drop for Decryptor<C> {
 
 #[cfg(feature = "zeroize")]
 #[cfg_attr(docsrs, doc(cfg(feature = "zeroize")))]
-impl<C: BlockEncryptMut + BlockCipher> Drop for BufDecryptor<C> {
-    fn drop(&mut self) {
-        self.iv.zeroize();
-    }
+impl<C, MBS> ZeroizeOnDrop for Decryptor<C, MBS>
+where
+    C: BlockEncryptMut + BlockCipher + ZeroizeOnDrop,
+    MBS: ArrayLength<u8>,
+{
 }
 
-#[cfg(feature = "zeroize")]
-#[cfg_attr(docsrs, doc(cfg(feature = "zeroize")))]
-impl<C: BlockEncryptMut + BlockCipher + ZeroizeOnDrop> ZeroizeOnDrop for Decryptor<C> {}
-
-#[cfg(feature = "zeroize")]
-#[cfg_attr(docsrs, doc(cfg(feature = "zeroize")))]
-impl<C: BlockEncryptMut + BlockCipher + ZeroizeOnDrop> ZeroizeOnDrop for BufDecryptor<C> {}
-
-struct Closure<'a, BS, BC>
+struct Closure<'a, CBS, MBS, BC>
 where
-    BS: ArrayLength<u8>,
-    BC: BlockClosure<BlockSize = BS>,
+    CBS: ArrayLength<u8>,
+    MBS: ArrayLength<u8>,
+    BC: BlockClosure<BlockSize = MBS>,
 {
-    iv: &'a mut GenericArray<u8, BS>,
+    iv: &'a mut GenericArray<u8, CBS>,
     f: BC,
+    _pd: PhantomData<MBS>,
 }
 
-impl<'a, BS, BC> BlockSizeUser for Closure<'a, BS, BC>
+impl<'a, CBS, MBS, BC> BlockSizeUser for Closure<'a, CBS, MBS, BC>
 where
-    BS: ArrayLength<u8>,
-    BC: BlockClosure<BlockSize = BS>,
+    CBS: ArrayLength<u8>,
+    MBS: ArrayLength<u8>,
+    BC: BlockClosure<BlockSize = MBS>,
 {
-    type BlockSize = BS;
+    type BlockSize = CBS;
 }
 
-impl<'a, BS, BC> BlockClosure for Closure<'a, BS, BC>
+impl<'a, CBS, MBS, BC> BlockClosure for Closure<'a, CBS, MBS, BC>
 where
-    BS: ArrayLength<u8>,
-    BC: BlockClosure<BlockSize = BS>,
+    CBS: ArrayLength<u8>,
+    MBS: ArrayLength<u8>,
+    BC: BlockClosure<BlockSize = MBS>,
 {
     #[inline(always)]
     fn call<B: BlockBackend<BlockSize = Self::BlockSize>>(self, backend: &mut B) {
-        let Self { iv, f } = self;
-        f.call(&mut Backend { iv, backend });
+        let Self { iv, f, _pd } = self;
+        f.call(&mut Backend { iv, backend, _pd });
     }
 }
 
-struct Backend<'a, BS, BK>
+struct Backend<'a, CBS, MBS, BK>
 where
-    BS: ArrayLength<u8>,
-    BK: BlockBackend<BlockSize = BS>,
+    CBS: ArrayLength<u8>,
+    MBS: ArrayLength<u8>,
+    BK: BlockBackend<BlockSize = CBS>,
 {
-    iv: &'a mut GenericArray<u8, BS>,
+    iv: &'a mut GenericArray<u8, CBS>,
     backend: &'a mut BK,
+    _pd: PhantomData<MBS>,
 }
 
-impl<'a, BS, BK> BlockSizeUser for Backend<'a, BS, BK>
+impl<'a, CBS, MBS, BK> BlockSizeUser for Backend<'a, CBS, MBS, BK>
 where
-    BS: ArrayLength<u8>,
-    BK: BlockBackend<BlockSize = BS>,
+    CBS: ArrayLength<u8>,
+    MBS: ArrayLength<u8>,
+    BK: BlockBackend<BlockSize = CBS>,
 {
-    type BlockSize = BS;
+    type BlockSize = MBS;
 }
 
-impl<'a, BS, BK> ParBlocksSizeUser for Backend<'a, BS, BK>
+impl<'a, CBS, MBS, BK> ParBlocksSizeUser for Backend<'a, CBS, MBS, BK>
 where
-    BS: ArrayLength<u8>,
-    BK: BlockBackend<BlockSize = BS>,
+    CBS: ArrayLength<u8>,
+    MBS: ArrayLength<u8>,
+    BK: BlockBackend<BlockSize = CBS>,
 {
-    type ParBlocksSize = BK::ParBlocksSize;
+    // It's possible to implement parallel decryption, but currently
+    // `ParBlocksSize` is tied to block size. Since cipher block size
+    // and method block size in general can be different, we can not
+    // write `type ParBlocksSize = BK::ParBlocksSize`.
+    type ParBlocksSize = U1;
 }
 
-impl<'a, BS, BK> BlockBackend for Backend<'a, BS, BK>
+impl<'a, CBS, MBS, BK> BlockBackend for Backend<'a, CBS, MBS, BK>
 where
-    BS: ArrayLength<u8>,
-    BK: BlockBackend<BlockSize = BS>,
+    CBS: ArrayLength<u8>,
+    MBS: ArrayLength<u8>,
+    BK: BlockBackend<BlockSize = CBS>,
 {
     #[inline(always)]
     fn proc_block(&mut self, mut block: InOut<'_, '_, Block<Self>>) {
-        let mut t = block.clone_in();
-        block.xor_in2out(self.iv);
-        self.backend.proc_block((&mut t).into());
-        *self.iv = t;
-    }
+        let cbs = CBS::USIZE;
+        let mbs = MBS::USIZE;
+        if mbs == cbs {
+            let mut t = block.clone_in();
+            block.xor_in2out(GenericArray::from_slice(&self.iv));
+            let block = GenericArray::from_mut_slice(&mut t);
+            self.backend.proc_block(block.into());
+            *self.iv = block.clone();
+        } else {
+            let mut t = self.iv.clone();
+            self.backend.proc_block((&mut t).into());
+            let ct = block.clone_in();
+            block.xor_in2out(GenericArray::from_slice(&t[..mbs]));
 
-    #[inline(always)]
-    fn proc_par_blocks(&mut self, mut blocks: InOut<'_, '_, ParBlocks<Self>>) {
-        let mut t = ParBlocks::<Self>::default();
-        let b = (blocks.get_in(), &mut t).into();
-        self.backend.proc_par_blocks(b);
-
-        let n = t.len();
-        blocks.get(0).xor_in2out(self.iv);
-        for i in 1..n {
-            blocks.get(i).xor_in2out(&t[i - 1])
+            let mid = cbs - mbs;
+            for i in 0..mid {
+                self.iv[i] = self.iv[i + 1];
+            }
+            self.iv[mid..].copy_from_slice(&ct);
         }
-        *self.iv = t[n - 1].clone();
     }
-}
 
-#[inline(always)]
-fn xor_set2(buf1: &mut [u8], buf2: &mut [u8]) {
-    for (a, b) in buf1.iter_mut().zip(buf2) {
-        let t = *a;
-        *a ^= *b;
-        *b = t;
-    }
+    // See comment in `ParBlocksSizeUser` impl
+    /*
+        #[inline(always)]
+        fn proc_par_blocks(&mut self, mut blocks: InOut<'_, '_, ParBlocks<Self>>) {
+            // let mut t = ParBlocks::<Self>::default();
+            // let b = (blocks.get_in(), &mut t).into();
+            // self.backend.proc_par_blocks(b);
+
+            // let n = t.len();
+            // blocks.get(0).xor_in2out(self.iv);
+            // for i in 1..n {
+            //     blocks.get(i).xor_in2out(&t[i - 1])
+            // }
+            // *self.iv = t[n - 1].clone();
+        }
+    */
 }

--- a/cfb-mode/src/encrypt.rs
+++ b/cfb-mode/src/encrypt.rs
@@ -4,156 +4,92 @@ use cipher::{
     generic_array::{ArrayLength, GenericArray},
     inout::InOut,
     AlgorithmName, AsyncStreamCipher, Block, BlockBackend, BlockCipher, BlockClosure, BlockDecrypt,
-    BlockEncryptMut, BlockSizeUser, InnerIvInit, Iv, IvState, ParBlocksSizeUser, Unsigned,
+    BlockEncryptMut, BlockSizeUser, InnerIvInit, Iv, IvState, ParBlocksSizeUser,
 };
-use core::fmt;
+use core::{fmt, marker::PhantomData};
 
 #[cfg(feature = "zeroize")]
 use cipher::zeroize::{Zeroize, ZeroizeOnDrop};
 
 /// CFB mode encryptor.
 #[derive(Clone)]
-pub struct Encryptor<C>
+pub struct Encryptor<C, MBS = <C as BlockSizeUser>::BlockSize>
 where
     C: BlockEncryptMut + BlockCipher,
+    MBS: ArrayLength<u8>,
 {
     cipher: C,
     iv: Block<C>,
+    _pd: PhantomData<MBS>,
 }
 
-/// CFB mode buffered encryptor.
-#[derive(Clone)]
-pub struct BufEncryptor<C>
+impl<C, MBS> BlockSizeUser for Encryptor<C, MBS>
 where
     C: BlockEncryptMut + BlockCipher,
+    MBS: ArrayLength<u8>,
 {
-    cipher: C,
-    iv: Block<C>,
-    pos: usize,
+    type BlockSize = MBS;
 }
 
-impl<C> BufEncryptor<C>
+impl<C, MBS> BlockEncryptMut for Encryptor<C, MBS>
 where
     C: BlockEncryptMut + BlockCipher,
-{
-    /// Encrypt a buffer in multiple parts.
-    pub fn encrypt(&mut self, mut data: &mut [u8]) {
-        let bs = C::BlockSize::USIZE;
-        let n = data.len();
-
-        if n < bs - self.pos {
-            xor_set1(data, &mut self.iv[self.pos..self.pos + n]);
-            self.pos += n;
-            return;
-        }
-
-        let (left, right) = { data }.split_at_mut(bs - self.pos);
-        data = right;
-        let mut iv = self.iv.clone();
-        xor_set1(left, &mut iv[self.pos..]);
-        self.cipher.encrypt_block_mut(&mut iv);
-
-        let mut chunks = data.chunks_exact_mut(bs);
-        for chunk in &mut chunks {
-            xor_set1(chunk, iv.as_mut_slice());
-            self.cipher.encrypt_block_mut(&mut iv);
-        }
-
-        let rem = chunks.into_remainder();
-        xor_set1(rem, iv.as_mut_slice());
-        self.pos = rem.len();
-        self.iv = iv;
-    }
-
-    /// Returns the current state (block and position) of the decryptor.
-    pub fn get_state(&self) -> (&Block<C>, usize) {
-        (&self.iv, self.pos)
-    }
-
-    /// Restore from the given state for resumption.
-    pub fn from_state(cipher: C, iv: &Block<C>, pos: usize) -> Self {
-        Self {
-            cipher,
-            iv: iv.clone(),
-            pos,
-        }
-    }
-}
-
-impl<C> BlockSizeUser for Encryptor<C>
-where
-    C: BlockEncryptMut + BlockCipher,
-{
-    type BlockSize = C::BlockSize;
-}
-
-impl<C> BlockEncryptMut for Encryptor<C>
-where
-    C: BlockEncryptMut + BlockCipher,
+    MBS: ArrayLength<u8>,
 {
     fn encrypt_with_backend_mut(&mut self, f: impl BlockClosure<BlockSize = Self::BlockSize>) {
-        let Self { cipher, iv } = self;
-        cipher.encrypt_with_backend_mut(Closure { iv, f })
+        let Self { cipher, iv, _pd } = self;
+        cipher.encrypt_with_backend_mut(Closure {
+            iv,
+            f,
+            _pd: _pd.clone(),
+        })
     }
 }
 
-impl<C> AsyncStreamCipher for Encryptor<C> where C: BlockEncryptMut + BlockCipher {}
-
-impl<C> InnerUser for Encryptor<C>
+impl<C, MBS> AsyncStreamCipher for Encryptor<C, MBS>
 where
     C: BlockEncryptMut + BlockCipher,
+    MBS: ArrayLength<u8>,
+{
+}
+
+impl<C, MBS> InnerUser for Encryptor<C, MBS>
+where
+    C: BlockEncryptMut + BlockCipher,
+    MBS: ArrayLength<u8>,
 {
     type Inner = C;
 }
 
-impl<C> InnerUser for BufEncryptor<C>
+impl<C, MBS> IvSizeUser for Encryptor<C, MBS>
 where
     C: BlockEncryptMut + BlockCipher,
-{
-    type Inner = C;
-}
-
-impl<C> IvSizeUser for Encryptor<C>
-where
-    C: BlockEncryptMut + BlockCipher,
+    MBS: ArrayLength<u8>,
 {
     type IvSize = C::BlockSize;
 }
 
-impl<C> IvSizeUser for BufEncryptor<C>
+impl<C, MBS> InnerIvInit for Encryptor<C, MBS>
 where
     C: BlockEncryptMut + BlockCipher,
-{
-    type IvSize = C::BlockSize;
-}
-
-impl<C> InnerIvInit for Encryptor<C>
-where
-    C: BlockEncryptMut + BlockCipher,
+    MBS: ArrayLength<u8>,
 {
     #[inline]
     fn inner_iv_init(mut cipher: C, iv: &Iv<Self>) -> Self {
         let mut iv = iv.clone();
         cipher.encrypt_block_mut(&mut iv);
-        Self { cipher, iv }
+        Self {
+            cipher,
+            iv,
+            _pd: PhantomData,
+        }
     }
 }
 
-impl<C> InnerIvInit for BufEncryptor<C>
-where
-    C: BlockEncryptMut + BlockCipher,
-{
-    #[inline]
-    fn inner_iv_init(mut cipher: C, iv: &Iv<Self>) -> Self {
-        let mut iv = iv.clone();
-        cipher.encrypt_block_mut(&mut iv);
-        Self { cipher, iv, pos: 0 }
-    }
-}
-
-impl<C> IvState for Encryptor<C>
+impl<C, MBS> IvState for Encryptor<C, MBS>
 where
     C: BlockEncryptMut + BlockDecrypt + BlockCipher,
+    MBS: ArrayLength<u8>,
 {
     #[inline]
     fn iv_state(&self) -> Iv<Self> {
@@ -163,20 +99,10 @@ where
     }
 }
 
-impl<C> AlgorithmName for BufEncryptor<C>
+impl<C, MBS> AlgorithmName for Encryptor<C, MBS>
 where
     C: BlockEncryptMut + BlockCipher + AlgorithmName,
-{
-    fn write_alg_name(f: &mut fmt::Formatter<'_>) -> fmt::Result {
-        f.write_str("cfb::BufEncryptor<")?;
-        <C as AlgorithmName>::write_alg_name(f)?;
-        f.write_str(">")
-    }
-}
-
-impl<C> AlgorithmName for Encryptor<C>
-where
-    C: BlockEncryptMut + BlockCipher + AlgorithmName,
+    MBS: ArrayLength<u8>,
 {
     fn write_alg_name(f: &mut fmt::Formatter<'_>) -> fmt::Result {
         f.write_str("cfb::Encryptor<")?;
@@ -185,9 +111,10 @@ where
     }
 }
 
-impl<C> fmt::Debug for Encryptor<C>
+impl<C, MBS> fmt::Debug for Encryptor<C, MBS>
 where
     C: BlockEncryptMut + BlockCipher + AlgorithmName,
+    MBS: ArrayLength<u8>,
 {
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
         f.write_str("cfb::Encryptor<")?;
@@ -196,20 +123,13 @@ where
     }
 }
 
-impl<C> fmt::Debug for BufEncryptor<C>
-where
-    C: BlockEncryptMut + BlockCipher + AlgorithmName,
-{
-    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
-        f.write_str("cfb::BufEncryptor<")?;
-        <C as AlgorithmName>::write_alg_name(f)?;
-        f.write_str("> { ... }")
-    }
-}
-
 #[cfg(feature = "zeroize")]
 #[cfg_attr(docsrs, doc(cfg(feature = "zeroize")))]
-impl<C: BlockEncryptMut + BlockCipher> Drop for Encryptor<C> {
+impl<C, MBS> Drop for Encryptor<C, MBS>
+where
+    C: BlockEncryptMut + BlockCipher,
+    MBS: ArrayLength<u8>,
+{
     fn drop(&mut self) {
         self.iv.zeroize();
     }
@@ -217,93 +137,102 @@ impl<C: BlockEncryptMut + BlockCipher> Drop for Encryptor<C> {
 
 #[cfg(feature = "zeroize")]
 #[cfg_attr(docsrs, doc(cfg(feature = "zeroize")))]
-impl<C: BlockEncryptMut + BlockCipher> Drop for BufEncryptor<C> {
-    fn drop(&mut self) {
-        self.iv.zeroize();
-    }
+impl<C, MBS> ZeroizeOnDrop for Encryptor<C, MBS>
+where
+    C: BlockEncryptMut + BlockCipher + ZeroizeOnDrop,
+    MBS: ArrayLength<u8>,
+{
 }
 
-#[cfg(feature = "zeroize")]
-#[cfg_attr(docsrs, doc(cfg(feature = "zeroize")))]
-impl<C: BlockEncryptMut + BlockCipher + ZeroizeOnDrop> ZeroizeOnDrop for Encryptor<C> {}
-
-#[cfg(feature = "zeroize")]
-#[cfg_attr(docsrs, doc(cfg(feature = "zeroize")))]
-impl<C: BlockEncryptMut + BlockCipher + ZeroizeOnDrop> ZeroizeOnDrop for BufEncryptor<C> {}
-
-struct Closure<'a, BS, BC>
+struct Closure<'a, CBS, MBS, BC>
 where
-    BS: ArrayLength<u8>,
-    BC: BlockClosure<BlockSize = BS>,
+    CBS: ArrayLength<u8>,
+    MBS: ArrayLength<u8>,
+    BC: BlockClosure<BlockSize = MBS>,
 {
-    iv: &'a mut GenericArray<u8, BS>,
+    iv: &'a mut GenericArray<u8, CBS>,
     f: BC,
+    _pd: PhantomData<MBS>,
 }
 
-impl<'a, BS, BC> BlockSizeUser for Closure<'a, BS, BC>
+impl<'a, CBS, MBS, BC> BlockSizeUser for Closure<'a, CBS, MBS, BC>
 where
-    BS: ArrayLength<u8>,
-    BC: BlockClosure<BlockSize = BS>,
+    CBS: ArrayLength<u8>,
+    MBS: ArrayLength<u8>,
+    BC: BlockClosure<BlockSize = MBS>,
 {
-    type BlockSize = BS;
+    type BlockSize = CBS;
 }
 
-impl<'a, BS, BC> BlockClosure for Closure<'a, BS, BC>
+impl<'a, CBS, MBS, BC> BlockClosure for Closure<'a, CBS, MBS, BC>
 where
-    BS: ArrayLength<u8>,
-    BC: BlockClosure<BlockSize = BS>,
+    CBS: ArrayLength<u8>,
+    MBS: ArrayLength<u8>,
+    BC: BlockClosure<BlockSize = MBS>,
 {
     #[inline(always)]
     fn call<B: BlockBackend<BlockSize = Self::BlockSize>>(self, backend: &mut B) {
-        let Self { iv, f } = self;
-        f.call(&mut Backend { iv, backend });
+        let Self { iv, f, _pd } = self;
+        f.call(&mut Backend { iv, backend, _pd });
     }
 }
 
-struct Backend<'a, BS, BK>
+struct Backend<'a, CBS, MBS, BK>
 where
-    BS: ArrayLength<u8>,
-    BK: BlockBackend<BlockSize = BS>,
+    CBS: ArrayLength<u8>,
+    MBS: ArrayLength<u8>,
+    BK: BlockBackend<BlockSize = CBS>,
 {
-    iv: &'a mut GenericArray<u8, BS>,
+    iv: &'a mut GenericArray<u8, CBS>,
     backend: &'a mut BK,
+    _pd: PhantomData<MBS>,
 }
 
-impl<'a, BS, BK> BlockSizeUser for Backend<'a, BS, BK>
+impl<'a, CBS, MBS, BK> BlockSizeUser for Backend<'a, CBS, MBS, BK>
 where
-    BS: ArrayLength<u8>,
-    BK: BlockBackend<BlockSize = BS>,
+    CBS: ArrayLength<u8>,
+    MBS: ArrayLength<u8>,
+    BK: BlockBackend<BlockSize = CBS>,
 {
-    type BlockSize = BS;
+    type BlockSize = MBS;
 }
 
-impl<'a, BS, BK> ParBlocksSizeUser for Backend<'a, BS, BK>
+impl<'a, CBS, MBS, BK> ParBlocksSizeUser for Backend<'a, CBS, MBS, BK>
 where
-    BS: ArrayLength<u8>,
-    BK: BlockBackend<BlockSize = BS>,
+    CBS: ArrayLength<u8>,
+    MBS: ArrayLength<u8>,
+    BK: BlockBackend<BlockSize = CBS>,
 {
     type ParBlocksSize = U1;
 }
 
-impl<'a, BS, BK> BlockBackend for Backend<'a, BS, BK>
+impl<'a, CBS, MBS, BK> BlockBackend for Backend<'a, CBS, MBS, BK>
 where
-    BS: ArrayLength<u8>,
-    BK: BlockBackend<BlockSize = BS>,
+    CBS: ArrayLength<u8>,
+    MBS: ArrayLength<u8>,
+    BK: BlockBackend<BlockSize = CBS>,
 {
     #[inline(always)]
     fn proc_block(&mut self, mut block: InOut<'_, '_, Block<Self>>) {
-        block.xor_in2out(self.iv);
-        let mut t = block.get_out().clone();
-        self.backend.proc_block((&mut t).into());
-        *self.iv = t;
-    }
-}
+        let cbs = CBS::USIZE;
+        let mbs = MBS::USIZE;
+        if mbs == cbs {
+            block.xor_in2out(GenericArray::from_slice(self.iv));
+            let mut t = block.get_out().clone();
+            let block = GenericArray::from_mut_slice(&mut t);
+            self.backend.proc_block(block.into());
+            self.iv.copy_from_slice(&t);
+        } else {
+            let mut t = self.iv.clone();
+            self.backend.proc_block((&mut t).into());
+            block.xor_in2out(GenericArray::from_slice(&t[..mbs]));
 
-#[inline(always)]
-fn xor_set1(buf1: &mut [u8], buf2: &mut [u8]) {
-    for (a, b) in buf1.iter_mut().zip(buf2) {
-        let t = *a ^ *b;
-        *a = t;
-        *b = t;
+            let ct = block.get_out();
+            let mid = cbs - mbs;
+            for i in 0..mid {
+                self.iv[i] = self.iv[i + mbs];
+            }
+            self.iv[mid..].copy_from_slice(&ct);
+        }
     }
 }

--- a/cfb-mode/src/lib.rs
+++ b/cfb-mode/src/lib.rs
@@ -59,9 +59,14 @@
 #![cfg_attr(docsrs, feature(doc_cfg))]
 #![warn(missing_docs, rust_2018_idioms)]
 
+pub use cipher;
+
+mod buf_decrypt;
+mod buf_encrypt;
 mod decrypt;
 mod encrypt;
 
-pub use cipher;
-pub use decrypt::{BufDecryptor, Decryptor};
-pub use encrypt::{BufEncryptor, Encryptor};
+pub use buf_decrypt::BufDecryptor;
+pub use buf_encrypt::BufEncryptor;
+pub use decrypt::Decryptor;
+pub use encrypt::Encryptor;


### PR DESCRIPTION
It makes the `cfb8` crate redundant and enables support of other CFB variants.

Unfortunately, it's currently impossible to preserve parallel decryption since `ParBlocksSize` gets tied to block size, which could be different for an underlying cipher and used mode, i.e. AES-CFB8 has cipher and mode block sizes equal to 16 and 1 respectively. In other words, with the current trait design we can not write `type ParBlocksSize = C::ParBlocksSize`, because `ParBlocksSize` is bounded by `ArrayLength<Block<Self>>`.

TODO:
- [ ] Make `BufEncryptor` and `BufDecryptor` generic over method block size
- [ ] Enforce that mode block size must be smaller or equal to cipher block size