### PR TITLE
fix: `missing_debug_implementations`

### DIFF
--- a/belt-ctr/src/lib.rs
+++ b/belt-ctr/src/lib.rs
@@ -33,12 +33,6 @@ where
     s_init: u128,
 }
 
-impl<C: BlockEncrypt + BlockSizeUser<BlockSize = U16>> fmt::Debug for BeltCtrCore<C> {
-    #[inline]
-    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
-        f.write_str("BeltCtrCore { ... }")
-    }
-}
 impl<C> StreamCipherCore for BeltCtrCore<C>
 where
     C: BlockEncrypt + BlockSizeUser<BlockSize = U16>,
@@ -115,5 +109,12 @@ where
         let mut t = self.s.to_le_bytes().into();
         self.cipher.decrypt_block(&mut t);
         t
+    }
+}
+
+impl<C: BlockEncrypt + BlockSizeUser<BlockSize = U16>> fmt::Debug for BeltCtrCore<C> {
+    #[inline]
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        f.write_str("BeltCtrCore { ... }")
     }
 }

--- a/belt-ctr/src/lib.rs
+++ b/belt-ctr/src/lib.rs
@@ -112,7 +112,7 @@ where
     }
 }
 
-impl<C> AlgorithmName for Encryptor<C>
+impl<C> AlgorithmName for BeltCtrCore<C>
 where
     C: BlockEncrypt + BlockDecrypt + BlockSizeUser<BlockSize = U16> + AlgorithmName,
 {

--- a/belt-ctr/src/lib.rs
+++ b/belt-ctr/src/lib.rs
@@ -12,9 +12,9 @@ pub use cipher;
 
 use belt_block::BeltBlock;
 use cipher::{
-    consts::U16, crypto_common::InnerUser, generic_array::GenericArray, BlockDecrypt, BlockEncrypt,
-    BlockSizeUser, InnerIvInit, Iv, IvSizeUser, IvState, StreamCipherCore, StreamCipherCoreWrapper,
-    StreamCipherSeekCore, StreamClosure,
+    consts::U16, crypto_common::InnerUser, generic_array::GenericArray, AlgorithmName,
+    BlockDecrypt, BlockEncrypt, BlockSizeUser, InnerIvInit, Iv, IvSizeUser, IvState,
+    StreamCipherCore, StreamCipherCoreWrapper, StreamCipherSeekCore, StreamClosure,
 };
 use core::fmt;
 
@@ -109,6 +109,17 @@ where
         let mut t = self.s.to_le_bytes().into();
         self.cipher.decrypt_block(&mut t);
         t
+    }
+}
+
+impl<C> AlgorithmName for Encryptor<C>
+where
+    C: BlockEncrypt + BlockDecrypt + BlockSizeUser<BlockSize = U16> + AlgorithmName,
+{
+    fn write_alg_name(f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        f.write_str("BeltCtr<")?;
+        <C as AlgorithmName>::write_alg_name(f)?;
+        f.write_str(">")
     }
 }
 

--- a/belt-ctr/src/lib.rs
+++ b/belt-ctr/src/lib.rs
@@ -6,7 +6,7 @@
 )]
 #![forbid(unsafe_code)]
 #![cfg_attr(docsrs, feature(doc_cfg))]
-#![warn(missing_docs, rust_2018_idioms)]
+#![warn(missing_debug_implementations, missing_docs, rust_2018_idioms)]
 
 pub use cipher;
 
@@ -16,6 +16,7 @@ use cipher::{
     BlockSizeUser, InnerIvInit, Iv, IvSizeUser, IvState, StreamCipherCore, StreamCipherCoreWrapper,
     StreamCipherSeekCore, StreamClosure,
 };
+use core::fmt;
 
 mod backend;
 
@@ -32,6 +33,12 @@ where
     s_init: u128,
 }
 
+impl<C: BlockEncrypt + BlockSizeUser<BlockSize = U16>> fmt::Debug for BeltCtrCore<C> {
+    #[inline]
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        f.write_str("BeltCtrCore { ... }")
+    }
+}
 impl<C> StreamCipherCore for BeltCtrCore<C>
 where
     C: BlockEncrypt + BlockSizeUser<BlockSize = U16>,

--- a/cbc/src/lib.rs
+++ b/cbc/src/lib.rs
@@ -95,7 +95,7 @@
 )]
 #![forbid(unsafe_code)]
 #![cfg_attr(docsrs, feature(doc_cfg))]
-#![warn(missing_docs, rust_2018_idioms)]
+#![warn(missing_debug_implementations, missing_docs, rust_2018_idioms)]
 
 mod decrypt;
 mod encrypt;

--- a/cfb-mode/src/lib.rs
+++ b/cfb-mode/src/lib.rs
@@ -59,7 +59,7 @@
 )]
 #![forbid(unsafe_code)]
 #![cfg_attr(docsrs, feature(doc_cfg))]
-#![warn(missing_docs, rust_2018_idioms)]
+#![warn(missing_debug_implementations, missing_docs, rust_2018_idioms)]
 
 mod decrypt;
 mod encrypt;

--- a/cfb8/src/lib.rs
+++ b/cfb8/src/lib.rs
@@ -59,7 +59,7 @@
 )]
 #![forbid(unsafe_code)]
 #![cfg_attr(docsrs, feature(doc_cfg))]
-#![warn(missing_docs, rust_2018_idioms)]
+#![warn(missing_debug_implementations, missing_docs, rust_2018_idioms)]
 
 mod decrypt;
 mod encrypt;

--- a/ctr/src/flavors/ctr128.rs
+++ b/ctr/src/flavors/ctr128.rs
@@ -4,6 +4,7 @@ use cipher::{
     generic_array::{ArrayLength, GenericArray},
     typenum::{PartialDiv, PartialQuot, Unsigned, U16},
 };
+use core::fmt;
 
 #[cfg(feature = "zeroize")]
 use cipher::zeroize::{Zeroize, ZeroizeOnDrop};
@@ -18,6 +19,13 @@ pub struct CtrNonce128<N: ArrayLength<u128>> {
     nonce: GenericArray<u128, N>,
 }
 
+impl<N: ArrayLength<u128>> fmt::Debug for CtrNonce128<N> {
+    #[inline]
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        f.write_str("CtrNonce128 { ... }")
+    }
+}
+
 #[cfg(feature = "zeroize")]
 impl<N: ArrayLength<u128>> Drop for CtrNonce128<N> {
     fn drop(&mut self) {
@@ -30,6 +38,7 @@ impl<N: ArrayLength<u128>> Drop for CtrNonce128<N> {
 impl<N: ArrayLength<u128>> ZeroizeOnDrop for CtrNonce128<N> {}
 
 /// 128-bit big endian counter flavor.
+#[derive(Debug)]
 pub enum Ctr128BE {}
 
 impl<B> CtrFlavor<B> for Ctr128BE
@@ -94,6 +103,7 @@ where
 }
 
 /// 128-bit big endian counter flavor.
+#[derive(Debug)]
 pub enum Ctr128LE {}
 
 impl<B> CtrFlavor<B> for Ctr128LE

--- a/ctr/src/flavors/ctr32.rs
+++ b/ctr/src/flavors/ctr32.rs
@@ -4,6 +4,7 @@ use cipher::{
     generic_array::{ArrayLength, GenericArray},
     typenum::{PartialDiv, PartialQuot, Unsigned, U4},
 };
+use core::fmt;
 
 #[cfg(feature = "zeroize")]
 use cipher::zeroize::{Zeroize, ZeroizeOnDrop};
@@ -18,6 +19,13 @@ pub struct CtrNonce32<N: ArrayLength<u32>> {
     nonce: GenericArray<u32, N>,
 }
 
+impl<N: ArrayLength<u32>> fmt::Debug for CtrNonce32<N> {
+    #[inline]
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        f.write_str("CtrNonce32 { ... }")
+    }
+}
+
 #[cfg(feature = "zeroize")]
 impl<N: ArrayLength<u32>> Drop for CtrNonce32<N> {
     fn drop(&mut self) {
@@ -30,6 +38,7 @@ impl<N: ArrayLength<u32>> Drop for CtrNonce32<N> {
 impl<N: ArrayLength<u32>> ZeroizeOnDrop for CtrNonce32<N> {}
 
 /// 32-bit big endian counter flavor.
+#[derive(Debug)]
 pub enum Ctr32BE {}
 
 impl<B> CtrFlavor<B> for Ctr32BE
@@ -94,6 +103,7 @@ where
 }
 
 /// 32-bit big endian counter flavor.
+#[derive(Debug)]
 pub enum Ctr32LE {}
 
 impl<B> CtrFlavor<B> for Ctr32LE

--- a/ctr/src/flavors/ctr64.rs
+++ b/ctr/src/flavors/ctr64.rs
@@ -4,6 +4,7 @@ use cipher::{
     generic_array::{ArrayLength, GenericArray},
     typenum::{PartialDiv, PartialQuot, Unsigned, U8},
 };
+use core::fmt;
 
 #[cfg(feature = "zeroize")]
 use cipher::zeroize::{Zeroize, ZeroizeOnDrop};
@@ -18,6 +19,13 @@ pub struct CtrNonce64<N: ArrayLength<u64>> {
     nonce: GenericArray<u64, N>,
 }
 
+impl<N: ArrayLength<u64>> fmt::Debug for CtrNonce64<N> {
+    #[inline]
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        f.write_str("CtrNonce64 { ... }")
+    }
+}
+
 #[cfg(feature = "zeroize")]
 impl<N: ArrayLength<u64>> Drop for CtrNonce64<N> {
     fn drop(&mut self) {
@@ -30,6 +38,7 @@ impl<N: ArrayLength<u64>> Drop for CtrNonce64<N> {
 impl<N: ArrayLength<u64>> ZeroizeOnDrop for CtrNonce64<N> {}
 
 /// 64-bit big endian counter flavor.
+#[derive(Debug)]
 pub enum Ctr64BE {}
 
 impl<B> CtrFlavor<B> for Ctr64BE
@@ -94,6 +103,7 @@ where
 }
 
 /// 64-bit big endian counter flavor.
+#[derive(Debug)]
 pub enum Ctr64LE {}
 
 impl<B> CtrFlavor<B> for Ctr64LE

--- a/ctr/src/lib.rs
+++ b/ctr/src/lib.rs
@@ -65,7 +65,7 @@
 )]
 #![forbid(unsafe_code)]
 #![cfg_attr(docsrs, feature(doc_cfg))]
-#![warn(missing_docs, rust_2018_idioms)]
+#![warn(missing_debug_implementations, missing_docs, rust_2018_idioms)]
 
 pub mod flavors;
 

--- a/ige/src/lib.rs
+++ b/ige/src/lib.rs
@@ -94,7 +94,7 @@
 )]
 #![forbid(unsafe_code)]
 #![cfg_attr(docsrs, feature(doc_cfg))]
-#![warn(missing_docs, rust_2018_idioms)]
+#![warn(missing_debug_implementations, missing_docs, rust_2018_idioms)]
 
 mod decrypt;
 mod encrypt;

--- a/ofb/src/lib.rs
+++ b/ofb/src/lib.rs
@@ -63,7 +63,7 @@
 )]
 #![forbid(unsafe_code)]
 #![cfg_attr(docsrs, feature(doc_cfg))]
-#![warn(missing_docs, rust_2018_idioms)]
+#![warn(missing_debug_implementations, missing_docs, rust_2018_idioms)]
 
 pub use cipher;
 

--- a/pcbc/src/lib.rs
+++ b/pcbc/src/lib.rs
@@ -95,7 +95,7 @@
 )]
 #![forbid(unsafe_code)]
 #![cfg_attr(docsrs, feature(doc_cfg))]
-#![warn(missing_docs, rust_2018_idioms)]
+#![warn(missing_debug_implementations, missing_docs, rust_2018_idioms)]
 
 mod decrypt;
 mod encrypt;


### PR DESCRIPTION
Sets `missing_debug_implementations` to warn and adds missing `std::fmt::Debug` implementations.

When tracing/logging/debugging a program it is common to debug print inputs and outputs of function, to do this generally dependencies need to offer `std::fmt::Debug` implementations.

I won't repeat what is written under [`missing_debug_implementations`](https://doc.rust-lang.org/rustc/lints/listing/allowed-by-default.html#missing-debug-implementations) which gives some more explanation.