### PR TITLE
ctr: fix incorrect doc comments about counter endian flavors

### DIFF
--- a/ctr/src/flavors/ctr128.rs
+++ b/ctr/src/flavors/ctr128.rs
@@ -102,7 +102,7 @@ where
     }
 }
 
-/// 128-bit big endian counter flavor.
+/// 128-bit little endian counter flavor.
 #[derive(Debug)]
 pub enum Ctr128LE {}
 

--- a/ctr/src/flavors/ctr32.rs
+++ b/ctr/src/flavors/ctr32.rs
@@ -102,7 +102,7 @@ where
     }
 }
 
-/// 32-bit big endian counter flavor.
+/// 32-bit little endian counter flavor.
 #[derive(Debug)]
 pub enum Ctr32LE {}
 

--- a/ctr/src/flavors/ctr64.rs
+++ b/ctr/src/flavors/ctr64.rs
@@ -102,7 +102,7 @@ where
     }
 }
 
-/// 64-bit big endian counter flavor.
+/// 64-bit little endian counter flavor.
 #[derive(Debug)]
 pub enum Ctr64LE {}
 


### PR DESCRIPTION
For RustCrypto members

Thank you for developing awesome crates!

I noticed a possible error in the documentation comment about endian flavors and have fixed it.

I would appreciate it if you could merge this PR, assuming there are no issues.

