### PR TITLE
bump hex-literal to 0.4 for cbc

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -52,7 +52,7 @@ version = "0.1.2"
 dependencies = [
  "aes",
  "cipher",
- "hex-literal 0.3.4",
+ "hex-literal 0.4.1",
 ]
 
 [[package]]

--- a/cbc/Cargo.toml
+++ b/cbc/Cargo.toml
@@ -18,7 +18,7 @@ cipher = "0.4.2"
 [dev-dependencies]
 aes = "0.8"
 cipher = { version = "0.4.2", features = ["dev"] }
-hex-literal = "0.3.3"
+hex-literal = "0.4"
 
 [features]
 default = ["block-padding"]


### PR DESCRIPTION
ref: https://salsa.debian.org/rust-team/debcargo-conf/-/blob/master/src/cbc/debian/patches/relax-deps.patch