### PR TITLE
Update `hex-literal` to v0.4

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4,8 +4,8 @@ version = 3
 
 [[package]]
 name = "aes"
-version = "0.9.0-pre"
-source = "git+https://github.com/RustCrypto/block-ciphers.git#c577715951ed183b7980a3b7499797723909c1dc"
+version = "0.9.0-pre.0"
+source = "git+https://github.com/RustCrypto/block-ciphers.git#ae1892c8600131227531504812260e3d2821d01e"
 dependencies = [
  "cfg-if",
  "cipher",
@@ -14,8 +14,8 @@ dependencies = [
 
 [[package]]
 name = "belt-block"
-version = "0.2.0-pre"
-source = "git+https://github.com/RustCrypto/block-ciphers.git#c577715951ed183b7980a3b7499797723909c1dc"
+version = "0.2.0-pre.0"
+source = "git+https://github.com/RustCrypto/block-ciphers.git#ae1892c8600131227531504812260e3d2821d01e"
 dependencies = [
  "cipher",
 ]
@@ -26,7 +26,7 @@ version = "0.2.0-pre"
 dependencies = [
  "belt-block",
  "cipher",
- "hex-literal 0.4.1",
+ "hex-literal",
 ]
 
 [[package]]
@@ -50,7 +50,7 @@ version = "0.2.0-pre"
 dependencies = [
  "aes",
  "cipher",
- "hex-literal 0.3.4",
+ "hex-literal",
 ]
 
 [[package]]
@@ -60,7 +60,7 @@ dependencies = [
  "aes",
  "belt-block",
  "cipher",
- "hex-literal 0.3.4",
+ "hex-literal",
 ]
 
 [[package]]
@@ -69,7 +69,7 @@ version = "0.9.0-pre"
 dependencies = [
  "aes",
  "cipher",
- "hex-literal 0.3.4",
+ "hex-literal",
 ]
 
 [[package]]
@@ -92,9 +92,9 @@ dependencies = [
 
 [[package]]
 name = "cpufeatures"
-version = "0.2.9"
+version = "0.2.12"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a17b76ff3a4162b0b27f354a0c87015ddad39d35f9c0c36607a3bdd175dde1f1"
+checksum = "53fe5e26ff1b7aef8bca9c6080520cfb8d9333c7568e1829cef191a9723e5504"
 dependencies = [
  "libc",
 ]
@@ -116,27 +116,21 @@ version = "0.10.0-pre"
 dependencies = [
  "aes",
  "cipher",
- "hex-literal 0.3.4",
+ "hex-literal",
  "kuznyechik",
  "magma",
 ]
 
 [[package]]
 name = "getrandom"
-version = "0.2.12"
+version = "0.2.15"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "190092ea657667030ac6a35e305e62fc4dd69fd98ac98631e5d3a2b1575a12b5"
+checksum = "c4567c8db10ae91089c99af84c68c38da3ec2f087c3f82960bcdbf3656b6f4d7"
 dependencies = [
  "cfg-if",
  "libc",
  "wasi",
 ]
-
-[[package]]
-name = "hex-literal"
-version = "0.3.4"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7ebdb29d2ea9ed0083cd8cece49bbd968021bd99b0849edb4a9a7ee0fdf6a4e0"
 
 [[package]]
 name = "hex-literal"
@@ -146,9 +140,9 @@ checksum = "6fe2267d4ed49bc07b63801559be28c718ea06c4738b7a03c94df7386d2cde46"
 
 [[package]]
 name = "hybrid-array"
-version = "0.2.0-rc.5"
+version = "0.2.0-rc.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "dcda354500b318c287a6b91c1cfbc42edd53d52d259a80783ceb5e3986fca2b2"
+checksum = "53668f5da5a41d9eaf4bf7064be46d1ebe6a4e1ceed817f387587b18f2b51047"
 dependencies = [
  "typenum",
 ]
@@ -159,7 +153,7 @@ version = "0.2.0-pre"
 dependencies = [
  "aes",
  "cipher",
- "hex-literal 0.3.4",
+ "hex-literal",
 ]
 
 [[package]]
@@ -174,22 +168,22 @@ dependencies = [
 
 [[package]]
 name = "kuznyechik"
-version = "0.9.0-pre"
-source = "git+https://github.com/RustCrypto/block-ciphers.git#c577715951ed183b7980a3b7499797723909c1dc"
+version = "0.9.0-pre.0"
+source = "git+https://github.com/RustCrypto/block-ciphers.git#ae1892c8600131227531504812260e3d2821d01e"
 dependencies = [
  "cipher",
 ]
 
 [[package]]
 name = "libc"
-version = "0.2.153"
+version = "0.2.155"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9c198f91728a82281a64e1f4f9eeb25d82cb32a5de251c6bd1b5154d63a8e7bd"
+checksum = "97b3888a4aecf77e811145cadf6eef5901f4782c53886191b2f693f24761847c"
 
 [[package]]
 name = "magma"
-version = "0.10.0-pre"
-source = "git+https://github.com/RustCrypto/block-ciphers.git#c577715951ed183b7980a3b7499797723909c1dc"
+version = "0.10.0-pre.0"
+source = "git+https://github.com/RustCrypto/block-ciphers.git#ae1892c8600131227531504812260e3d2821d01e"
 dependencies = [
  "cipher",
 ]
@@ -200,7 +194,7 @@ version = "0.7.0-pre"
 dependencies = [
  "aes",
  "cipher",
- "hex-literal 0.3.4",
+ "hex-literal",
 ]
 
 [[package]]
@@ -209,7 +203,7 @@ version = "0.2.0-pre"
 dependencies = [
  "aes",
  "cipher",
- "hex-literal 0.3.4",
+ "hex-literal",
 ]
 
 [[package]]
@@ -235,6 +229,6 @@ checksum = "9c8d87e72b64a3b4db28d11ce29237c246188f4f51057d65a7eab63b7987e423"
 
 [[package]]
 name = "zeroize"
-version = "1.7.0"
+version = "1.8.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "525b4ec142c6b68a2d10f01f7bbf6755599ca3f81ea53b8431b7dd348f5fdb2d"
+checksum = "ced3678a2879b30306d323f4542626697a464a97c0a07c9aebf7ebca65cd4dde"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,4 +1,5 @@
 [workspace]
+resolver = "2"
 members = [
     "belt-ctr",
     "cbc",

--- a/belt-ctr/Cargo.toml
+++ b/belt-ctr/Cargo.toml
@@ -14,11 +14,11 @@ categories = ["cryptography", "no-std"]
 
 [dependencies]
 cipher = "=0.5.0-pre.4"
-belt-block = "=0.2.0-pre"
+belt-block = "=0.2.0-pre.0"
 
 [dev-dependencies]
 hex-literal = "0.4"
-belt-block = "=0.2.0-pre"
+belt-block = "=0.2.0-pre.0"
 cipher = { version = "=0.5.0-pre.4", features = ["dev"] }
 
 [features]

--- a/cbc/Cargo.toml
+++ b/cbc/Cargo.toml
@@ -16,9 +16,9 @@ categories = ["cryptography", "no-std"]
 cipher = "=0.5.0-pre.4"
 
 [dev-dependencies]
-aes = "=0.9.0-pre"
+aes = "=0.9.0-pre.0"
 cipher = { version = "=0.5.0-pre.4", features = ["dev"] }
-hex-literal = "0.4.1"
+hex-literal = "0.4"
 
 [features]
 default = ["block-padding"]

--- a/cfb-mode/Cargo.toml
+++ b/cfb-mode/Cargo.toml
@@ -16,10 +16,10 @@ categories = ["cryptography", "no-std"]
 cipher = "=0.5.0-pre.4"
 
 [dev-dependencies]
-aes = "=0.9.0-pre"
-belt-block = "=0.2.0-pre"
+aes = "=0.9.0-pre.0"
+belt-block = "=0.2.0-pre.0"
 cipher = { version = "=0.5.0-pre.4", features = ["dev"] }
-hex-literal = "0.3"
+hex-literal = "0.4"
 
 [features]
 alloc = ["cipher/alloc"]

--- a/cfb8/Cargo.toml
+++ b/cfb8/Cargo.toml
@@ -16,9 +16,9 @@ categories = ["cryptography", "no-std"]
 cipher = "=0.5.0-pre.4"
 
 [dev-dependencies]
-aes = "=0.9.0-pre"
+aes = "=0.9.0-pre.0"
 cipher = { version = "=0.5.0-pre.4", features = ["dev"] }
-hex-literal = "0.3"
+hex-literal = "0.4"
 
 [features]
 alloc = ["cipher/alloc"]

--- a/ctr/Cargo.toml
+++ b/ctr/Cargo.toml
@@ -16,11 +16,11 @@ categories = ["cryptography", "no-std"]
 cipher = "=0.5.0-pre.4"
 
 [dev-dependencies]
-aes = "=0.9.0-pre"
-magma = "=0.10.0-pre"
-kuznyechik = "=0.9.0-pre"
+aes = "=0.9.0-pre.0"
+magma = "=0.10.0-pre.0"
+kuznyechik = "=0.9.0-pre.0"
 cipher = { version = "=0.5.0-pre.4", features = ["dev"] }
-hex-literal = "0.3.3"
+hex-literal = "0.4"
 
 [features]
 alloc = ["cipher/alloc"]

--- a/ige/Cargo.toml
+++ b/ige/Cargo.toml
@@ -16,9 +16,9 @@ categories = ["cryptography", "no-std"]
 cipher = "=0.5.0-pre.4"
 
 [dev-dependencies]
-aes = "=0.9.0-pre"
+aes = "=0.9.0-pre.0"
 cipher = { version = "=0.5.0-pre.4", features = ["dev"] }
-hex-literal = "0.3.3"
+hex-literal = "0.4"
 
 [features]
 default = ["block-padding"]

--- a/ofb/Cargo.toml
+++ b/ofb/Cargo.toml
@@ -16,9 +16,9 @@ categories = ["cryptography", "no-std"]
 cipher = "=0.5.0-pre.4"
 
 [dev-dependencies]
-aes = "=0.9.0-pre"
+aes = "=0.9.0-pre.0"
 cipher = { version = "=0.5.0-pre.4", features = ["dev"] }
-hex-literal = "0.3"
+hex-literal = "0.4"
 
 [features]
 alloc = ["cipher/alloc"]

--- a/pcbc/Cargo.toml
+++ b/pcbc/Cargo.toml
@@ -16,9 +16,9 @@ categories = ["cryptography", "no-std"]
 cipher = "=0.5.0-pre.4"
 
 [dev-dependencies]
-aes = "=0.9.0-pre"
+aes = "=0.9.0-pre.0"
 cipher = { version = "=0.5.0-pre.4", features = ["dev"] }
-hex-literal = "0.3.3"
+hex-literal = "0.4"
 
 [features]
 default = ["block-padding"]


### PR DESCRIPTION
Also updates cipher crate versions.