### PR TITLE
Cut `rc.0` prereleases

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -24,7 +24,7 @@ dependencies = [
 
 [[package]]
 name = "belt-ctr"
-version = "0.2.0-pre"
+version = "0.2.0-rc.0"
 dependencies = [
  "belt-block",
  "cipher",
@@ -48,7 +48,7 @@ dependencies = [
 
 [[package]]
 name = "cbc"
-version = "0.2.0-pre.2"
+version = "0.2.0-rc.0"
 dependencies = [
  "aes",
  "cipher",
@@ -57,7 +57,7 @@ dependencies = [
 
 [[package]]
 name = "cfb-mode"
-version = "0.9.0-pre"
+version = "0.9.0-rc.0"
 dependencies = [
  "aes",
  "belt-block",
@@ -67,7 +67,7 @@ dependencies = [
 
 [[package]]
 name = "cfb8"
-version = "0.9.0-pre"
+version = "0.9.0-rc.0"
 dependencies = [
  "aes",
  "cipher",
@@ -112,7 +112,7 @@ dependencies = [
 
 [[package]]
 name = "ctr"
-version = "0.10.0-pre.2"
+version = "0.10.0-rc.0"
 dependencies = [
  "aes",
  "cipher",
@@ -123,7 +123,7 @@ dependencies = [
 
 [[package]]
 name = "cts"
-version = "0.6.0"
+version = "0.7.0-rc.0"
 dependencies = [
  "aes",
  "belt-block",
@@ -149,7 +149,7 @@ dependencies = [
 
 [[package]]
 name = "ige"
-version = "0.2.0-pre"
+version = "0.2.0-rc.0"
 dependencies = [
  "aes",
  "cipher",
@@ -193,7 +193,7 @@ dependencies = [
 
 [[package]]
 name = "ofb"
-version = "0.7.0-pre"
+version = "0.7.0-rc.0"
 dependencies = [
  "aes",
  "cipher",
@@ -202,7 +202,7 @@ dependencies = [
 
 [[package]]
 name = "pcbc"
-version = "0.2.0-pre"
+version = "0.2.0-rc.0"
 dependencies = [
  "aes",
  "cipher",

--- a/belt-ctr/Cargo.toml
+++ b/belt-ctr/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "belt-ctr"
-version = "0.2.0-pre"
+version = "0.2.0-rc.0"
 description = "CTR block mode of operation specified by the BelT standard"
 authors = ["RustCrypto Developers"]
 license = "MIT OR Apache-2.0"

--- a/belt-ctr/README.md
+++ b/belt-ctr/README.md
@@ -2,10 +2,10 @@
 
 [![crate][crate-image]][crate-link]
 [![Docs][docs-image]][docs-link]
+[![Build Status][build-image]][build-link]
 ![Apache2/MIT licensed][license-image]
 ![Rust Version][rustc-image]
 [![Project Chat][chat-image]][chat-link]
-[![Build Status][build-image]][build-link]
 
 Generic implementation of the [`belt-ctr`] block mode of operation.
 
@@ -61,7 +61,7 @@ dual licensed as above, without any additional terms or conditions.
 
 [//]: # (badges)
 
-[crate-image]: https://img.shields.io/crates/v/belt-ctr.svg
+[crate-image]: https://img.shields.io/crates/v/belt-ctr.svg?logo=rust
 [crate-link]: https://crates.io/crates/belt-ctr
 [docs-image]: https://docs.rs/belt-ctr/badge.svg
 [docs-link]: https://docs.rs/belt-ctr/
@@ -69,8 +69,8 @@ dual licensed as above, without any additional terms or conditions.
 [rustc-image]: https://img.shields.io/badge/rustc-1.85+-blue.svg
 [chat-image]: https://img.shields.io/badge/zulip-join_chat-blue.svg
 [chat-link]: https://rustcrypto.zulipchat.com/#narrow/stream/308460-block-modes
-[build-image]: https://github.com/RustCrypto/block-modes/workflows/belt-ctr/badge.svg?branch=master&event=push
-[build-link]: https://github.com/RustCrypto/block-modes/actions?query=workflow%3Abelt-ctr+branch%3Amaster
+[build-image]: https://github.com/RustCrypto/block-modes/actions/workflows/belt-ctr.yaml/badge.svg
+[build-link]: https://github.com/RustCrypto/block-modes/actions/workflows/belt-ctr.yaml
 
 [//]: # (general links)
 

--- a/cbc/Cargo.toml
+++ b/cbc/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "cbc"
-version = "0.2.0-pre.2"
+version = "0.2.0-rc.0"
 description = "Cipher Block Chaining (CBC) block cipher mode of operation"
 authors = ["RustCrypto Developers"]
 license = "MIT OR Apache-2.0"

--- a/cbc/README.md
+++ b/cbc/README.md
@@ -2,10 +2,10 @@
 
 [![crate][crate-image]][crate-link]
 [![Docs][docs-image]][docs-link]
+[![Build Status][build-image]][build-link]
 ![Apache2/MIT licensed][license-image]
 ![Rust Version][rustc-image]
 [![Project Chat][chat-image]][chat-link]
-[![Build Status][build-image]][build-link]
 
 Generic implementation of the [Cipher Block Chaining][CBC] (CBC) block cipher
 mode of operation.
@@ -31,7 +31,7 @@ dual licensed as above, without any additional terms or conditions.
 
 [//]: # (badges)
 
-[crate-image]: https://img.shields.io/crates/v/cbc.svg
+[crate-image]: https://img.shields.io/crates/v/cbc.svg?logo=rust
 [crate-link]: https://crates.io/crates/cbc
 [docs-image]: https://docs.rs/cbc/badge.svg
 [docs-link]: https://docs.rs/cbc/
@@ -39,8 +39,8 @@ dual licensed as above, without any additional terms or conditions.
 [rustc-image]: https://img.shields.io/badge/rustc-1.85+-blue.svg
 [chat-image]: https://img.shields.io/badge/zulip-join_chat-blue.svg
 [chat-link]: https://rustcrypto.zulipchat.com/#narrow/stream/308460-block-modes
-[build-image]: https://github.com/RustCrypto/block-modes/workflows/cbc/badge.svg?branch=master&event=push
-[build-link]: https://github.com/RustCrypto/block-modes/actions?query=workflow%3Acbc+branch%3Amaster
+[build-image]: https://github.com/RustCrypto/block-modes/actions/workflows/cbc.yaml/badge.svg
+[build-link]: https://github.com/RustCrypto/block-modes/actions/workflows/cbc.yaml
 
 [//]: # (general links)
 

--- a/cfb-mode/Cargo.toml
+++ b/cfb-mode/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "cfb-mode"
-version = "0.9.0-pre"
+version = "0.9.0-rc.0"
 description = "Cipher Feedback (CFB) block cipher mode of operation"
 authors = ["RustCrypto Developers"]
 license = "MIT OR Apache-2.0"

--- a/cfb-mode/README.md
+++ b/cfb-mode/README.md
@@ -2,10 +2,10 @@
 
 [![crate][crate-image]][crate-link]
 [![Docs][docs-image]][docs-link]
+[![Build Status][build-image]][build-link]
 ![Apache2/MIT licensed][license-image]
 ![Rust Version][rustc-image]
 [![Project Chat][chat-image]][chat-link]
-[![Build Status][build-image]][build-link]
 
 Generic implementation of the [Cipher Feedback][CFB] (CFB) block cipher mode
 of operation.
@@ -31,7 +31,7 @@ dual licensed as above, without any additional terms or conditions.
 
 [//]: # (badges)
 
-[crate-image]: https://img.shields.io/crates/v/cfb-mode.svg
+[crate-image]: https://img.shields.io/crates/v/cfb-mode.svg?logo=rust
 [crate-link]: https://crates.io/crates/cfb-mode
 [docs-image]: https://docs.rs/cfb-mode/badge.svg
 [docs-link]: https://docs.rs/cfb-mode/
@@ -39,8 +39,8 @@ dual licensed as above, without any additional terms or conditions.
 [rustc-image]: https://img.shields.io/badge/rustc-1.85+-blue.svg
 [chat-image]: https://img.shields.io/badge/zulip-join_chat-blue.svg
 [chat-link]: https://rustcrypto.zulipchat.com/#narrow/stream/308460-block-modes
-[build-image]: https://github.com/RustCrypto/block-modes/workflows/cfb-mode/badge.svg?branch=master&event=push
-[build-link]: https://github.com/RustCrypto/block-modes/actions?query=workflow%3Acfb-mode+branch%3Amaster
+[build-image]: https://github.com/RustCrypto/block-modes/actions/workflows/cfb-mode.yaml/badge.svg
+[build-link]: https://github.com/RustCrypto/block-modes/actions/workflows/cfb-mode.yaml
 
 [//]: # (general links)
 

--- a/cfb8/Cargo.toml
+++ b/cfb8/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "cfb8"
-version = "0.9.0-pre"
+version = "0.9.0-rc.0"
 description = "Cipher Feedback with eight bit feedback (CFB-8) block cipher mode of operation"
 authors = ["RustCrypto Developers"]
 license = "MIT OR Apache-2.0"

--- a/cfb8/README.md
+++ b/cfb8/README.md
@@ -2,10 +2,10 @@
 
 [![crate][crate-image]][crate-link]
 [![Docs][docs-image]][docs-link]
+[![Build Status][build-image]][build-link]
 ![Apache2/MIT licensed][license-image]
 ![Rust Version][rustc-image]
 [![Project Chat][chat-image]][chat-link]
-[![Build Status][build-image]][build-link]
 
 Generic implementation of the [Cipher Feedback][CFB-8] with eight bit
 feedback (CFB-8) block cipher mode of operation.
@@ -31,7 +31,7 @@ dual licensed as above, without any additional terms or conditions.
 
 [//]: # (badges)
 
-[crate-image]: https://img.shields.io/crates/v/cfb8.svg
+[crate-image]: https://img.shields.io/crates/v/cfb8.svg?logo=rust
 [crate-link]: https://crates.io/crates/cfb8
 [docs-image]: https://docs.rs/cfb8/badge.svg
 [docs-link]: https://docs.rs/cfb8/
@@ -39,8 +39,8 @@ dual licensed as above, without any additional terms or conditions.
 [rustc-image]: https://img.shields.io/badge/rustc-1.85+-blue.svg
 [chat-image]: https://img.shields.io/badge/zulip-join_chat-blue.svg
 [chat-link]: https://rustcrypto.zulipchat.com/#narrow/stream/308460-block-modes
-[build-image]: https://github.com/RustCrypto/block-modes/workflows/cfb8/badge.svg?branch=master&event=push
-[build-link]: https://github.com/RustCrypto/block-modes/actions?query=workflow%3Acfb+branch%3Amaster
+[build-image]: https://github.com/RustCrypto/block-modes/actions/workflows/cfb8.yaml/badge.svg
+[build-link]: https://github.com/RustCrypto/block-modes/actions/workflows/cfb8.yaml
 
 [//]: # (general links)
 

--- a/ctr/Cargo.toml
+++ b/ctr/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "ctr"
-version = "0.10.0-pre.2"
+version = "0.10.0-rc.0"
 description = "CTR block modes of operation"
 authors = ["RustCrypto Developers"]
 license = "MIT OR Apache-2.0"

--- a/ctr/README.md
+++ b/ctr/README.md
@@ -3,9 +3,9 @@
 [![crate][crate-image]][crate-link]
 [![Docs][docs-image]][docs-link]
 ![Apache2/MIT licensed][license-image]
+[![Build Status][build-image]][build-link]
 ![Rust Version][rustc-image]
 [![Project Chat][chat-image]][chat-link]
-[![Build Status][build-image]][build-link]
 
 Generic implementation of the [Counter][CTR] (CTR) block cipher mode of operation.
 
@@ -30,7 +30,7 @@ dual licensed as above, without any additional terms or conditions.
 
 [//]: # (badges)
 
-[crate-image]: https://img.shields.io/crates/v/ctr.svg
+[crate-image]: https://img.shields.io/crates/v/ctr.svg?logo=rust
 [crate-link]: https://crates.io/crates/ctr
 [docs-image]: https://docs.rs/ctr/badge.svg
 [docs-link]: https://docs.rs/ctr/
@@ -38,8 +38,8 @@ dual licensed as above, without any additional terms or conditions.
 [rustc-image]: https://img.shields.io/badge/rustc-1.85+-blue.svg
 [chat-image]: https://img.shields.io/badge/zulip-join_chat-blue.svg
 [chat-link]: https://rustcrypto.zulipchat.com/#narrow/stream/308460-block-modes
-[build-image]: https://github.com/RustCrypto/block-modes/workflows/ctr/badge.svg?branch=master&event=push
-[build-link]: https://github.com/RustCrypto/block-modes/actions?query=workflow%3Actr+branch%3Amaster
+[build-image]: https://github.com/RustCrypto/block-modes/actions/workflows/ctr.yaml/badge.svg
+[build-link]: https://github.com/RustCrypto/block-modes/actions/workflows/ctr.yaml
 
 [//]: # (general links)
 

--- a/cts/Cargo.toml
+++ b/cts/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "cts"
-version = "0.6.0"
+version = "0.7.0-rc.0"
 description = "Generic implementation of the ciphertext stealing block modes of operation"
 authors = ["RustCrypto Developers"]
 license = "MIT OR Apache-2.0"

--- a/cts/README.md
+++ b/cts/README.md
@@ -2,10 +2,10 @@
 
 [![crate][crate-image]][crate-link]
 [![Docs][docs-image]][docs-link]
+[![Build Status][build-image]][build-link]
 ![Apache2/MIT licensed][license-image]
 ![Rust Version][rustc-image]
 [![Project Chat][chat-image]][chat-link]
-[![Build Status][build-image]][build-link]
 
 Generic implementation of the [ciphertext stealing] block cipher modes of operation.
 
@@ -80,7 +80,7 @@ dual licensed as above, without any additional terms or conditions.
 
 [//]: # (badges)
 
-[crate-image]: https://img.shields.io/crates/v/cts.svg
+[crate-image]: https://img.shields.io/crates/v/cts.svg?logo=rust
 [crate-link]: https://crates.io/crates/cts
 [docs-image]: https://docs.rs/cts/badge.svg
 [docs-link]: https://docs.rs/cts/
@@ -88,8 +88,8 @@ dual licensed as above, without any additional terms or conditions.
 [rustc-image]: https://img.shields.io/badge/rustc-1.85+-blue.svg
 [chat-image]: https://img.shields.io/badge/zulip-join_chat-blue.svg
 [chat-link]: https://rustcrypto.zulipchat.com/#narrow/stream/308460-block-modes
-[build-image]: https://github.com/RustCrypto/block-modes/workflows/cts/badge.svg?branch=master&event=push
-[build-link]: https://github.com/RustCrypto/block-modes/actions?query=workflow%3Acts+branch%3Amaster
+[build-image]: https://github.com/RustCrypto/block-modes/actions/workflows/cts.yaml/badge.svg
+[build-link]: https://github.com/RustCrypto/block-modes/actions/workflows/cts.yaml
 
 [//]: # (general links)
 

--- a/ige/Cargo.toml
+++ b/ige/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "ige"
-version = "0.2.0-pre"
+version = "0.2.0-rc.0"
 description = "Infinite Garble Extension (IGE) block cipher mode of operation"
 authors = ["RustCrypto Developers"]
 license = "MIT OR Apache-2.0"

--- a/ige/README.md
+++ b/ige/README.md
@@ -2,10 +2,10 @@
 
 [![crate][crate-image]][crate-link]
 [![Docs][docs-image]][docs-link]
+[![Build Status][build-image]][build-link]
 ![Apache2/MIT licensed][license-image]
 ![Rust Version][rustc-image]
 [![Project Chat][chat-image]][chat-link]
-[![Build Status][build-image]][build-link]
 
 Generic implementation of the [Infinite Garble Extension][IGE] (IGE)
 block cipher mode of operation.
@@ -31,7 +31,7 @@ dual licensed as above, without any additional terms or conditions.
 
 [//]: # (badges)
 
-[crate-image]: https://img.shields.io/crates/v/ige.svg
+[crate-image]: https://img.shields.io/crates/v/ige.svg?logo=rust
 [crate-link]: https://crates.io/crates/ige
 [docs-image]: https://docs.rs/ige/badge.svg
 [docs-link]: https://docs.rs/ige/
@@ -39,8 +39,8 @@ dual licensed as above, without any additional terms or conditions.
 [rustc-image]: https://img.shields.io/badge/rustc-1.85+-blue.svg
 [chat-image]: https://img.shields.io/badge/zulip-join_chat-blue.svg
 [chat-link]: https://rustcrypto.zulipchat.com/#narrow/stream/308460-block-modes
-[build-image]: https://github.com/RustCrypto/block-modes/workflows/ige/badge.svg?branch=master&event=push
-[build-link]: https://github.com/RustCrypto/block-modes/actions?query=workflow%3Aige+branch%3Amaster
+[build-image]: https://github.com/RustCrypto/block-modes/actions/workflows/ige.yaml/badge.svg
+[build-link]: https://github.com/RustCrypto/block-modes/actions/workflows/ige.yaml
 
 [//]: # (general links)
 

--- a/ofb/Cargo.toml
+++ b/ofb/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "ofb"
-version = "0.7.0-pre"
+version = "0.7.0-rc.0"
 description = "Output Feedback (OFB) block cipher mode of operation"
 authors = ["RustCrypto Developers"]
 license = "MIT OR Apache-2.0"

--- a/ofb/README.md
+++ b/ofb/README.md
@@ -2,10 +2,10 @@
 
 [![crate][crate-image]][crate-link]
 [![Docs][docs-image]][docs-link]
+[![Build Status][build-image]][build-link]
 ![Apache2/MIT licensed][license-image]
 ![Rust Version][rustc-image]
 [![Project Chat][chat-image]][chat-link]
-[![Build Status][build-image]][build-link]
 
 Generic implementation of the [Output Feedback][OFB] (OFB) block cipher mode
 of operation.
@@ -31,7 +31,7 @@ dual licensed as above, without any additional terms or conditions.
 
 [//]: # (badges)
 
-[crate-image]: https://img.shields.io/crates/v/ofb.svg
+[crate-image]: https://img.shields.io/crates/v/ofb.svg?logo=rust
 [crate-link]: https://crates.io/crates/ofb
 [docs-image]: https://docs.rs/ofb/badge.svg
 [docs-link]: https://docs.rs/ofb/
@@ -39,8 +39,8 @@ dual licensed as above, without any additional terms or conditions.
 [rustc-image]: https://img.shields.io/badge/rustc-1.85+-blue.svg
 [chat-image]: https://img.shields.io/badge/zulip-join_chat-blue.svg
 [chat-link]: https://rustcrypto.zulipchat.com/#narrow/stream/308460-block-modes
-[build-image]: https://github.com/RustCrypto/block-modes/workflows/ofb/badge.svg?branch=master&event=push
-[build-link]: https://github.com/RustCrypto/block-modes/actions?query=workflow%3Aofb+branch%3Amaster
+[build-image]: https://github.com/RustCrypto/block-modes/actions/workflows/ofb.yaml/badge.svg
+[build-link]: https://github.com/RustCrypto/block-modes/actions/workflows/ofb.yaml
 
 [//]: # (general links)
 

--- a/pcbc/Cargo.toml
+++ b/pcbc/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "pcbc"
-version = "0.2.0-pre"
+version = "0.2.0-rc.0"
 description = "Propagating Cipher Block Chaining (PCBC) block cipher mode of operation"
 authors = ["RustCrypto Developers"]
 license = "MIT OR Apache-2.0"

--- a/pcbc/README.md
+++ b/pcbc/README.md
@@ -2,10 +2,10 @@
 
 [![crate][crate-image]][crate-link]
 [![Docs][docs-image]][docs-link]
+[![Build Status][build-image]][build-link]
 ![Apache2/MIT licensed][license-image]
 ![Rust Version][rustc-image]
 [![Project Chat][chat-image]][chat-link]
-[![Build Status][build-image]][build-link]
 
 Generic implementation of the [Propagating Cipher Block Chaining][PCBC] (PCBC)
 block cipher mode of operation.
@@ -31,7 +31,7 @@ dual licensed as above, without any additional terms or conditions.
 
 [//]: # (badges)
 
-[crate-image]: https://img.shields.io/crates/v/pcbc.svg
+[crate-image]: https://img.shields.io/crates/v/pcbc.svg?logo=rust
 [crate-link]: https://crates.io/crates/pcbc
 [docs-image]: https://docs.rs/pcbc/badge.svg
 [docs-link]: https://docs.rs/pcbc/
@@ -39,8 +39,8 @@ dual licensed as above, without any additional terms or conditions.
 [rustc-image]: https://img.shields.io/badge/rustc-1.85+-blue.svg
 [chat-image]: https://img.shields.io/badge/zulip-join_chat-blue.svg
 [chat-link]: https://rustcrypto.zulipchat.com/#narrow/stream/308460-block-modes
-[build-image]: https://github.com/RustCrypto/block-modes/workflows/pcbc/badge.svg?branch=master&event=push
-[build-link]: https://github.com/RustCrypto/block-modes/actions?query=workflow%3Apcbc+branch%3Amaster
+[build-image]: https://github.com/RustCrypto/block-modes/actions/workflows/pcbc.yaml/badge.svg
+[build-link]: https://github.com/RustCrypto/block-modes/actions/workflows/pbcb.yaml
 
 [//]: # (general links)
 


### PR DESCRIPTION
These all incorporate `cipher` v0.5.0-rc.0