### PR TITLE
Bump `cipher` to v0.5.0-rc.1

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -39,8 +39,9 @@ checksum = "4a859067dcb257cb2ae028cb821399b55140b76fb8b2a360e052fe109019db43"
 
 [[package]]
 name = "block-buffer"
-version = "0.11.0-rc.4"
-source = "git+https://github.com/RustCrypto/utils#adfccfea2686ef191b607f653cc3587753b6ec66"
+version = "0.11.0-rc.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e9ef36a6fcdb072aa548f3da057640ec10859eb4e91ddf526ee648d50c76a949"
 dependencies = [
  "hybrid-array",
  "zeroize",
@@ -48,8 +49,9 @@ dependencies = [
 
 [[package]]
 name = "block-padding"
-version = "0.4.0-rc.3"
-source = "git+https://github.com/RustCrypto/utils#adfccfea2686ef191b607f653cc3587753b6ec66"
+version = "0.4.0-rc.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7e59c1aab3e6c5e56afe1b7e8650be9b5a791cb997bdea449194ae62e4bf8c73"
 dependencies = [
  "hybrid-array",
 ]
@@ -90,8 +92,9 @@ checksum = "baf1de4339761588bc0619e3cbc0120ee582ebb74b53b4efbf79117bd2da40fd"
 
 [[package]]
 name = "cipher"
-version = "0.5.0-rc.0"
-source = "git+https://github.com/RustCrypto/traits#b91704f633a83798c1ba89f908cff067ddc7d843"
+version = "0.5.0-rc.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1e12a13eb01ded5d32ee9658d94f553a19e804204f2dc811df69ab4d9e0cb8c7"
 dependencies = [
  "blobby",
  "block-buffer",
@@ -111,8 +114,9 @@ dependencies = [
 
 [[package]]
 name = "crypto-common"
-version = "0.2.0-rc.3"
-source = "git+https://github.com/RustCrypto/traits#b91704f633a83798c1ba89f908cff067ddc7d843"
+version = "0.2.0-rc.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6a8235645834fbc6832939736ce2f2d08192652269e11010a6240f61b908a1c6"
 dependencies = [
  "hybrid-array",
 ]
@@ -165,8 +169,9 @@ dependencies = [
 
 [[package]]
 name = "inout"
-version = "0.2.0-rc.5"
-source = "git+https://github.com/RustCrypto/utils#adfccfea2686ef191b607f653cc3587753b6ec66"
+version = "0.2.0-rc.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1603f76010ff924b616c8f44815a42eb10fb0b93d308b41deaa8da6d4251fd4b"
 dependencies = [
  "block-padding",
  "hybrid-array",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -14,11 +14,3 @@ members = [
 
 [profile.dev]
 opt-level = 2
-
-[patch.crates-io]
-# https://github.com/RustCrypto/utils/pull/1208
-block-buffer = { git = "https://github.com/RustCrypto/utils" }
-# https://github.com/RustCrypto/traits/pull/1976
-cipher = { git = "https://github.com/RustCrypto/traits" }
-# https://github.com/RustCrypto/utils/pull/1208
-inout = { git = "https://github.com/RustCrypto/utils" }

--- a/belt-ctr/Cargo.toml
+++ b/belt-ctr/Cargo.toml
@@ -13,13 +13,13 @@ keywords = ["crypto", "block-mode", "stream-cipher", "ciphers", "belt"]
 categories = ["cryptography", "no-std"]
 
 [dependencies]
-cipher = { version = "0.5.0-rc.0", features = ["stream-wrapper"] }
+cipher = { version = "0.5.0-rc.1", features = ["stream-wrapper"] }
 belt-block = "0.2.0-rc.0"
 
 [dev-dependencies]
 hex-literal = "1"
 belt-block = "0.2.0-rc.0"
-cipher = { version = "0.5.0-rc.0", features = ["dev"] }
+cipher = { version = "0.5.0-rc.1", features = ["dev"] }
 
 [features]
 alloc = ["cipher/alloc"]

--- a/cbc/Cargo.toml
+++ b/cbc/Cargo.toml
@@ -13,11 +13,11 @@ keywords = ["crypto", "block-mode", "ciphers"]
 categories = ["cryptography", "no-std"]
 
 [dependencies]
-cipher = "0.5.0-rc.0"
+cipher = "0.5.0-rc.1"
 
 [dev-dependencies]
 aes = "0.9.0-rc.0"
-cipher = { version = "0.5.0-rc.0", features = ["dev"] }
+cipher = { version = "0.5.0-rc.1", features = ["dev"] }
 hex-literal = "1"
 
 [features]

--- a/cfb-mode/Cargo.toml
+++ b/cfb-mode/Cargo.toml
@@ -13,12 +13,12 @@ keywords = ["crypto", "block-mode", "stream-cipher", "ciphers"]
 categories = ["cryptography", "no-std"]
 
 [dependencies]
-cipher = "0.5.0-rc.0"
+cipher = "0.5.0-rc.1"
 
 [dev-dependencies]
 aes = "0.9.0-rc.0"
 belt-block = "0.2.0-rc.0"
-cipher = { version = "0.5.0-rc.0", features = ["dev"] }
+cipher = { version = "0.5.0-rc.1", features = ["dev"] }
 hex-literal = "1"
 
 [features]

--- a/cfb8/Cargo.toml
+++ b/cfb8/Cargo.toml
@@ -13,11 +13,11 @@ keywords = ["crypto", "block-mode", "stream-cipher", "ciphers"]
 categories = ["cryptography", "no-std"]
 
 [dependencies]
-cipher = "0.5.0-rc.0"
+cipher = "0.5.0-rc.1"
 
 [dev-dependencies]
 aes = "0.9.0-rc.0"
-cipher = { version = "0.5.0-rc.0", features = ["dev"] }
+cipher = { version = "0.5.0-rc.1", features = ["dev"] }
 hex-literal = "1"
 
 [features]

--- a/ctr/Cargo.toml
+++ b/ctr/Cargo.toml
@@ -13,13 +13,13 @@ keywords = ["crypto", "block-mode", "stream-cipher", "ciphers"]
 categories = ["cryptography", "no-std"]
 
 [dependencies]
-cipher = { version = "0.5.0-rc.0", features = ["stream-wrapper"] }
+cipher = { version = "0.5.0-rc.1", features = ["stream-wrapper"] }
 
 [dev-dependencies]
 aes = "0.9.0-rc.0"
 magma = "0.10.0-rc.0"
 kuznyechik = "0.9.0-rc.0"
-cipher = { version = "0.5.0-rc.0", features = ["dev"] }
+cipher = { version = "0.5.0-rc.1", features = ["dev"] }
 hex-literal = "1"
 
 [features]

--- a/cts/Cargo.toml
+++ b/cts/Cargo.toml
@@ -13,10 +13,10 @@ keywords = ["crypto", "block-mode", "ciphers"]
 categories = ["cryptography", "no-std"]
 
 [dependencies]
-cipher = "0.5.0-rc.0"
+cipher = "0.5.0-rc.1"
 
 [dev-dependencies]
-cipher = { version = "0.5.0-rc.0", features = ["dev"] }
+cipher = { version = "0.5.0-rc.1", features = ["dev"] }
 hex-literal = "1"
 aes = "0.9.0-rc.0"
 belt-block = "0.2.0-rc.0"

--- a/ige/Cargo.toml
+++ b/ige/Cargo.toml
@@ -13,11 +13,11 @@ keywords = ["crypto", "block-mode", "ciphers"]
 categories = ["cryptography", "no-std"]
 
 [dependencies]
-cipher = "0.5.0-rc.0"
+cipher = "0.5.0-rc.1"
 
 [dev-dependencies]
 aes = "0.9.0-rc.0"
-cipher = { version = "0.5.0-rc.0", features = ["dev"] }
+cipher = { version = "0.5.0-rc.1", features = ["dev"] }
 hex-literal = "1"
 
 [features]

--- a/ofb/Cargo.toml
+++ b/ofb/Cargo.toml
@@ -13,11 +13,11 @@ keywords = ["crypto", "block-mode", "stream-cipher", "ciphers"]
 categories = ["cryptography", "no-std"]
 
 [dependencies]
-cipher = { version = "0.5.0-rc.0", features = ["stream-wrapper"] }
+cipher = { version = "0.5.0-rc.1", features = ["stream-wrapper"] }
 
 [dev-dependencies]
 aes = "0.9.0-rc.0"
-cipher = { version = "0.5.0-rc.0", features = ["dev"] }
+cipher = { version = "0.5.0-rc.1", features = ["dev"] }
 hex-literal = "1"
 
 [features]

--- a/pcbc/Cargo.toml
+++ b/pcbc/Cargo.toml
@@ -13,11 +13,11 @@ keywords = ["crypto", "block-mode", "ciphers"]
 categories = ["cryptography", "no-std"]
 
 [dependencies]
-cipher = "0.5.0-rc.0"
+cipher = "0.5.0-rc.1"
 
 [dev-dependencies]
 aes = "0.9.0-rc.0"
-cipher = { version = "0.5.0-rc.0", features = ["dev"] }
+cipher = { version = "0.5.0-rc.1", features = ["dev"] }
 hex-literal = "1"
 
 [features]


### PR DESCRIPTION
Notably this includes hybrid-array v0.4 support