### PR TITLE
Cut prereleases with `hybrid-array` v0.4 support

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -24,7 +24,7 @@ dependencies = [
 
 [[package]]
 name = "belt-ctr"
-version = "0.2.0-rc.0"
+version = "0.2.0-rc.1"
 dependencies = [
  "belt-block",
  "cipher",
@@ -58,7 +58,7 @@ dependencies = [
 
 [[package]]
 name = "cbc"
-version = "0.2.0-rc.0"
+version = "0.2.0-rc.1"
 dependencies = [
  "aes",
  "cipher",
@@ -67,7 +67,7 @@ dependencies = [
 
 [[package]]
 name = "cfb-mode"
-version = "0.9.0-rc.0"
+version = "0.9.0-rc.1"
 dependencies = [
  "aes",
  "belt-block",
@@ -77,7 +77,7 @@ dependencies = [
 
 [[package]]
 name = "cfb8"
-version = "0.9.0-rc.0"
+version = "0.9.0-rc.1"
 dependencies = [
  "aes",
  "cipher",
@@ -123,7 +123,7 @@ dependencies = [
 
 [[package]]
 name = "ctr"
-version = "0.10.0-rc.0"
+version = "0.10.0-rc.1"
 dependencies = [
  "aes",
  "cipher",
@@ -134,7 +134,7 @@ dependencies = [
 
 [[package]]
 name = "cts"
-version = "0.7.0-rc.0"
+version = "0.7.0-rc.1"
 dependencies = [
  "aes",
  "belt-block",
@@ -160,7 +160,7 @@ dependencies = [
 
 [[package]]
 name = "ige"
-version = "0.2.0-rc.0"
+version = "0.2.0-rc.1"
 dependencies = [
  "aes",
  "cipher",
@@ -204,7 +204,7 @@ dependencies = [
 
 [[package]]
 name = "ofb"
-version = "0.7.0-rc.0"
+version = "0.7.0-rc.1"
 dependencies = [
  "aes",
  "cipher",
@@ -213,7 +213,7 @@ dependencies = [
 
 [[package]]
 name = "pcbc"
-version = "0.2.0-rc.0"
+version = "0.2.0-rc.1"
 dependencies = [
  "aes",
  "cipher",

--- a/belt-ctr/Cargo.toml
+++ b/belt-ctr/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "belt-ctr"
-version = "0.2.0-rc.0"
+version = "0.2.0-rc.1"
 description = "CTR block mode of operation specified by the BelT standard"
 authors = ["RustCrypto Developers"]
 license = "MIT OR Apache-2.0"

--- a/cbc/Cargo.toml
+++ b/cbc/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "cbc"
-version = "0.2.0-rc.0"
+version = "0.2.0-rc.1"
 description = "Cipher Block Chaining (CBC) block cipher mode of operation"
 authors = ["RustCrypto Developers"]
 license = "MIT OR Apache-2.0"

--- a/cfb-mode/Cargo.toml
+++ b/cfb-mode/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "cfb-mode"
-version = "0.9.0-rc.0"
+version = "0.9.0-rc.1"
 description = "Cipher Feedback (CFB) block cipher mode of operation"
 authors = ["RustCrypto Developers"]
 license = "MIT OR Apache-2.0"

--- a/cfb8/Cargo.toml
+++ b/cfb8/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "cfb8"
-version = "0.9.0-rc.0"
+version = "0.9.0-rc.1"
 description = "Cipher Feedback with eight bit feedback (CFB-8) block cipher mode of operation"
 authors = ["RustCrypto Developers"]
 license = "MIT OR Apache-2.0"

--- a/ctr/Cargo.toml
+++ b/ctr/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "ctr"
-version = "0.10.0-rc.0"
+version = "0.10.0-rc.1"
 description = "CTR block modes of operation"
 authors = ["RustCrypto Developers"]
 license = "MIT OR Apache-2.0"

--- a/cts/Cargo.toml
+++ b/cts/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "cts"
-version = "0.7.0-rc.0"
+version = "0.7.0-rc.1"
 description = "Generic implementation of the ciphertext stealing block modes of operation"
 authors = ["RustCrypto Developers"]
 license = "MIT OR Apache-2.0"

--- a/ige/Cargo.toml
+++ b/ige/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "ige"
-version = "0.2.0-rc.0"
+version = "0.2.0-rc.1"
 description = "Infinite Garble Extension (IGE) block cipher mode of operation"
 authors = ["RustCrypto Developers"]
 license = "MIT OR Apache-2.0"

--- a/ofb/Cargo.toml
+++ b/ofb/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "ofb"
-version = "0.7.0-rc.0"
+version = "0.7.0-rc.1"
 description = "Output Feedback (OFB) block cipher mode of operation"
 authors = ["RustCrypto Developers"]
 license = "MIT OR Apache-2.0"

--- a/pcbc/Cargo.toml
+++ b/pcbc/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "pcbc"
-version = "0.2.0-rc.0"
+version = "0.2.0-rc.1"
 description = "Propagating Cipher Block Chaining (PCBC) block cipher mode of operation"
 authors = ["RustCrypto Developers"]
 license = "MIT OR Apache-2.0"


### PR DESCRIPTION
Releases the following:
- `belt-ctr` v0.2.0-rc.1
- `cbc` v0.2.0-rc.1
- `cfb-mode` v0.9.0-rc.1
- `cfb8` v0.9.0-rc.1
- `ctr` v0.10.0-rc.1
- `cts` v0.7.0-rc.1
- `ige` v0.2.0-rc.1
- `ofb` v0.7.0-rc.1
- `pcbc` v0.2.0-rc.1