### PR TITLE
Remove `Clone` impls

### DIFF
--- a/cbc/CHANGELOG.md
+++ b/cbc/CHANGELOG.md
@@ -8,6 +8,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ## 0.2.0 (UNRELEASED)
 ### Removed 
 - `std` feature ([#76])
+- `Clone` impl ([#91])
 
 ### Changed
 - Bump `cipher` from `0.4` to `0.5` ([#56])
@@ -16,6 +17,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 [#56]: https://github.com/RustCrypto/block-modes/pull/56
 [#76]: https://github.com/RustCrypto/block-modes/pull/76
+[#91]: https://github.com/RustCrypto/block-modes/pull/91
 
 ## 0.1.2 (2022-03-24)
 ### Changed

--- a/cbc/src/decrypt.rs
+++ b/cbc/src/decrypt.rs
@@ -13,7 +13,6 @@ use core::fmt;
 use cipher::zeroize::{Zeroize, ZeroizeOnDrop};
 
 /// CBC mode decryptor.
-#[derive(Clone)]
 pub struct Decryptor<C>
 where
     C: BlockCipherDecrypt,

--- a/cbc/src/encrypt.rs
+++ b/cbc/src/encrypt.rs
@@ -12,7 +12,6 @@ use core::fmt;
 use cipher::zeroize::{Zeroize, ZeroizeOnDrop};
 
 /// CBC mode encryptor.
-#[derive(Clone)]
 pub struct Encryptor<C>
 where
     C: BlockCipherEncrypt,

--- a/cfb-mode/CHANGELOG.md
+++ b/cfb-mode/CHANGELOG.md
@@ -8,6 +8,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ## 0.9.0 (UNRELEASED)
 ### Removed 
 - `std` feature ([#76])
+- `Clone` impl ([#91])
 
 ### Changed
 - Bump `cipher` from `0.4` to `0.5` ([#56])
@@ -16,6 +17,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 [#56]: https://github.com/RustCrypto/block-modes/pull/56
 [#76]: https://github.com/RustCrypto/block-modes/pull/76
+[#91]: https://github.com/RustCrypto/block-modes/pull/91
 
 ## 0.8.2 (2022-09-13)
 ### Added

--- a/cfb-mode/src/decrypt.rs
+++ b/cfb-mode/src/decrypt.rs
@@ -12,7 +12,6 @@ use core::fmt;
 use cipher::zeroize::{Zeroize, ZeroizeOnDrop};
 
 /// CFB mode decryptor.
-#[derive(Clone)]
 pub struct Decryptor<C>
 where
     C: BlockCipherEncrypt,
@@ -22,7 +21,6 @@ where
 }
 
 /// CFB mode buffered decryptor.
-#[derive(Clone)]
 pub struct BufDecryptor<C>
 where
     C: BlockCipherEncrypt,

--- a/cfb-mode/src/encrypt.rs
+++ b/cfb-mode/src/encrypt.rs
@@ -16,7 +16,6 @@ mod buf;
 pub use buf::BufEncryptor;
 
 /// CFB mode encryptor.
-#[derive(Clone)]
 pub struct Encryptor<C>
 where
     C: BlockCipherEncrypt,

--- a/cfb-mode/src/encrypt/buf.rs
+++ b/cfb-mode/src/encrypt/buf.rs
@@ -9,7 +9,6 @@ use core::fmt;
 use cipher::zeroize::{Zeroize, ZeroizeOnDrop};
 
 /// CFB mode buffered encryptor.
-#[derive(Clone)]
 pub struct BufEncryptor<C>
 where
     C: BlockCipherEncrypt,

--- a/cfb8/CHANGELOG.md
+++ b/cfb8/CHANGELOG.md
@@ -8,6 +8,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ## 0.9.0 (UNRELEASED)
 ### Removed 
 - `std` feature ([#76])
+- `Clone` impl ([#91])
 
 ### Changed
 - Bump `cipher` from `0.4` to `0.5` ([#56])
@@ -16,6 +17,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 [#56]: https://github.com/RustCrypto/block-modes/pull/56
 [#75]: https://github.com/RustCrypto/block-modes/pull/76
+[#91]: https://github.com/RustCrypto/block-modes/pull/91
 
 ## 0.8.1 (2022-02-17)
 ### Fixed

--- a/cfb8/src/decrypt.rs
+++ b/cfb8/src/decrypt.rs
@@ -13,7 +13,6 @@ use core::fmt;
 use cipher::zeroize::{Zeroize, ZeroizeOnDrop};
 
 /// CFB-8 mode decryptor.
-#[derive(Clone)]
 pub struct Decryptor<C>
 where
     C: BlockCipherEncrypt,

--- a/cfb8/src/encrypt.rs
+++ b/cfb8/src/encrypt.rs
@@ -13,7 +13,6 @@ use core::fmt;
 use cipher::zeroize::{Zeroize, ZeroizeOnDrop};
 
 /// CFB-8 mode encryptor.
-#[derive(Clone)]
 pub struct Encryptor<C>
 where
     C: BlockCipherEncrypt,

--- a/ctr/CHANGELOG.md
+++ b/ctr/CHANGELOG.md
@@ -8,6 +8,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ## 0.10.0 (UNRELEASED)
 ### Removed 
 - `std` feature ([#76])
+- `Clone` impl ([#91])
 
 ### Changed
 - Bump `cipher` from `0.4` to `0.5` ([#56])
@@ -16,7 +17,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 [#56]: https://github.com/RustCrypto/block-modes/pull/56
 [#76]: https://github.com/RustCrypto/block-modes/pull/76
-
+[#91]: https://github.com/RustCrypto/block-modes/pull/91
 
 ## 0.9.2 (2022-09-30)
 ### Changed

--- a/ctr/src/ctr_core.rs
+++ b/ctr/src/ctr_core.rs
@@ -151,20 +151,6 @@ where
     }
 }
 
-impl<C, F> Clone for CtrCore<C, F>
-where
-    C: BlockCipherEncrypt + Clone,
-    F: CtrFlavor<C::BlockSize>,
-{
-    #[inline]
-    fn clone(&self) -> Self {
-        Self {
-            cipher: self.cipher.clone(),
-            ctr_nonce: self.ctr_nonce.clone(),
-        }
-    }
-}
-
 impl<C, F> fmt::Debug for CtrCore<C, F>
 where
     C: BlockCipherEncrypt + AlgorithmName,

--- a/cts/CHANGELOG.md
+++ b/cts/CHANGELOG.md
@@ -8,6 +8,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ## 0.7.0 (UNRELEASED)
 ### Removed 
 - `std` feature ([#76])
+- `Clone` impl ([#91])
 
 ### Changed
 - Update to cipher v0.5 ([#72])
@@ -17,6 +18,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 [#72]: https://github.com/RustCrypto/block-modes/pull/72
 [#76]: https://github.com/RustCrypto/block-modes/pull/76
+[#91]: https://github.com/RustCrypto/block-modes/pull/91
 
 ## 0.6.0 (2024-11-01)
 - Initial release ([#70])

--- a/cts/src/cbc_cs1.rs
+++ b/cts/src/cbc_cs1.rs
@@ -9,7 +9,6 @@ use cipher::{
 };
 
 /// The CBC-CS-1 ciphertext stealing mode.
-#[derive(Clone)]
 pub struct CbcCs1<C: BlockSizeUser> {
     cipher: C,
     iv: Block<C>,

--- a/cts/src/cbc_cs2.rs
+++ b/cts/src/cbc_cs2.rs
@@ -9,7 +9,6 @@ use cipher::{
 };
 
 /// The CBC-CS-2 ciphertext stealing mode.
-#[derive(Clone)]
 pub struct CbcCs2<C: BlockSizeUser> {
     cipher: C,
     iv: Block<C>,

--- a/cts/src/cbc_cs3.rs
+++ b/cts/src/cbc_cs3.rs
@@ -9,7 +9,6 @@ use cipher::{
 };
 
 /// The CBC-CS-3 ciphertext stealing mode.
-#[derive(Clone)]
 pub struct CbcCs3<C: BlockSizeUser> {
     cipher: C,
     iv: Block<C>,

--- a/cts/src/ecb_cs1.rs
+++ b/cts/src/ecb_cs1.rs
@@ -10,7 +10,6 @@ use cipher::{
 };
 
 /// The ECB-CS-1 ciphertext stealing mode.
-#[derive(Clone)]
 pub struct EcbCs1<C: BlockSizeUser> {
     cipher: C,
 }

--- a/cts/src/ecb_cs2.rs
+++ b/cts/src/ecb_cs2.rs
@@ -10,7 +10,6 @@ use cipher::{
 };
 
 /// The ECB-CS-2 ciphertext stealing mode.
-#[derive(Clone)]
 pub struct EcbCs2<C: BlockSizeUser> {
     cipher: C,
 }

--- a/cts/src/ecb_cs3.rs
+++ b/cts/src/ecb_cs3.rs
@@ -10,7 +10,6 @@ use cipher::{
 };
 
 /// The ECB-CS-3 ciphertext stealing mode.
-#[derive(Clone)]
 pub struct EcbCs3<C: BlockSizeUser> {
     cipher: C,
 }

--- a/ige/CHANGELOG.md
+++ b/ige/CHANGELOG.md
@@ -8,6 +8,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ## 0.2.0 (UNRELEASED)
 ### Removed 
 - `std` feature ([#76])
+- `Clone` impl ([#91])
 
 ### Changed
 - Bump `cipher` from `0.4` to `0.5` ([#56])
@@ -16,6 +17,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 [#56]: https://github.com/RustCrypto/block-modes/pull/56
 [#76]: https://github.com/RustCrypto/block-modes/pull/76
+[#91]: https://github.com/RustCrypto/block-modes/pull/91
 
 ## 0.1.1 (2022-02-17)
 ### Fixed

--- a/ige/src/decrypt.rs
+++ b/ige/src/decrypt.rs
@@ -14,7 +14,6 @@ use core::{fmt, ops::Add};
 use cipher::zeroize::{Zeroize, ZeroizeOnDrop};
 
 /// IGE mode decryptor.
-#[derive(Clone)]
 pub struct Decryptor<C>
 where
     C: BlockCipherDecrypt,

--- a/ige/src/encrypt.rs
+++ b/ige/src/encrypt.rs
@@ -14,7 +14,6 @@ use core::{fmt, ops::Add};
 use cipher::zeroize::{Zeroize, ZeroizeOnDrop};
 
 /// IGE mode encryptor.
-#[derive(Clone)]
 pub struct Encryptor<C>
 where
     C: BlockCipherEncrypt,

--- a/ofb/CHANGELOG.md
+++ b/ofb/CHANGELOG.md
@@ -8,6 +8,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ## 0.7.0 (UNRELEASED)
 ### Removed 
 - `std` feature ([#76])
+- `Clone` impl ([#91])
 
 ### Changed
 - Bump `cipher` from `0.4` to `0.5` ([#56])
@@ -16,6 +17,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 [#56]: https://github.com/RustCrypto/block-modes/pull/56
 [#76]: https://github.com/RustCrypto/block-modes/pull/76
+[#91]: https://github.com/RustCrypto/block-modes/pull/91
 
 ## 0.6.1 (2022-02-17)
 ### Fixed

--- a/ofb/src/lib.rs
+++ b/ofb/src/lib.rs
@@ -85,7 +85,6 @@ use cipher::zeroize::{Zeroize, ZeroizeOnDrop};
 pub type Ofb<C> = StreamCipherCoreWrapper<OfbCore<C>>;
 
 /// Output feedback (OFB) mode.
-#[derive(Clone)]
 pub struct OfbCore<C>
 where
     C: BlockCipherEncrypt,

--- a/pcbc/CHANGELOG.md
+++ b/pcbc/CHANGELOG.md
@@ -8,6 +8,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ## 0.2.0 (UNRELEASED)
 ### Removed 
 - `std` feature ([#76])
+- `Clone` impl ([#91])
 
 ### Changed
 - Bump `cipher` from `0.4` to `0.5` ([#56])
@@ -16,6 +17,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 [#56]: https://github.com/RustCrypto/block-modes/pull/56
 [#76]: https://github.com/RustCrypto/block-modes/pull/76
+[#91]: https://github.com/RustCrypto/block-modes/pull/91
 
 ## 0.1.2 (2022-03-24)
 ### Changed

--- a/pcbc/src/decrypt.rs
+++ b/pcbc/src/decrypt.rs
@@ -14,7 +14,6 @@ use core::fmt;
 use cipher::zeroize::{Zeroize, ZeroizeOnDrop};
 
 /// PCBC mode decryptor.
-#[derive(Clone)]
 pub struct Decryptor<C>
 where
     C: BlockCipherDecrypt,

--- a/pcbc/src/encrypt.rs
+++ b/pcbc/src/encrypt.rs
@@ -14,7 +14,6 @@ use core::fmt;
 use cipher::zeroize::{Zeroize, ZeroizeOnDrop};
 
 /// PCBC mode encryptor.
-#[derive(Clone)]
 pub struct Encryptor<C>
 where
     C: BlockCipherEncrypt,


### PR DESCRIPTION
Cloning of a block mode state can be considered a footgun. If state has to be cloned for some reason, users should prefer passing key/IV instead (see the `IvState` trait).

Previous discussion: https://github.com/rust-random/rand/issues/1101

Note that we previously had people complaining about `Clone`: https://github.com/RustCrypto/block-modes/issues/23