### PR TITLE
Add `allow(missing_docs)` for benchmarks

### DIFF
--- a/belt-ctr/benches/belt-ctr.rs
+++ b/belt-ctr/benches/belt-ctr.rs
@@ -1,4 +1,5 @@
 #![feature(test)]
+#![allow(missing_docs)]
 extern crate test;
 
 cipher::stream_cipher_bench!(

--- a/cbc/benches/aes128.rs
+++ b/cbc/benches/aes128.rs
@@ -1,4 +1,5 @@
 #![feature(test)]
+#![allow(missing_docs)]
 extern crate test;
 
 cipher::block_encryptor_bench!(

--- a/cfb-mode/benches/aes128.rs
+++ b/cfb-mode/benches/aes128.rs
@@ -1,4 +1,5 @@
 #![feature(test)]
+#![allow(missing_docs)]
 extern crate test;
 
 cipher::block_encryptor_bench!(

--- a/cfb8/benches/aes128.rs
+++ b/cfb8/benches/aes128.rs
@@ -1,4 +1,5 @@
 #![feature(test)]
+#![allow(missing_docs)]
 extern crate test;
 
 cipher::block_encryptor_bench!(

--- a/ctr/benches/aes128.rs
+++ b/ctr/benches/aes128.rs
@@ -1,4 +1,5 @@
 #![feature(test)]
+#![allow(missing_docs)]
 extern crate test;
 
 cipher::stream_cipher_bench!(

--- a/ige/benches/aes128.rs
+++ b/ige/benches/aes128.rs
@@ -1,4 +1,5 @@
 #![feature(test)]
+#![allow(missing_docs)]
 extern crate test;
 
 cipher::block_encryptor_bench!(

--- a/ofb/benches/aes128.rs
+++ b/ofb/benches/aes128.rs
@@ -1,4 +1,5 @@
 #![feature(test)]
+#![allow(missing_docs)]
 extern crate test;
 
 cipher::stream_cipher_bench!(

--- a/pcbc/benches/aes128.rs
+++ b/pcbc/benches/aes128.rs
@@ -1,4 +1,5 @@
 #![feature(test)]
+#![allow(missing_docs)]
 extern crate test;
 
 cipher::block_encryptor_bench!(


### PR DESCRIPTION
Addition of simple module docs is not sufficient since `block_encryptor_bench!` creates `pub fn`.