### PR TITLE
belt-ctr: use type alias to define `BeltCtr`

### DIFF
--- a/belt-ctr/CHANGELOG.md
+++ b/belt-ctr/CHANGELOG.md
@@ -5,5 +5,19 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/)
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## 0.2.0 (UNRELEASED)
+## Added
+- `GenericBeltCtr` and `GenericBeltCtrCore` types ([#112])
+
+## Changed
+- Bump `cipher` from `0.4` to `0.5` ([#56])
+- Edition changed to 2024 and MSRV bumped to 1.85 ([#76])
+- Relax MSRV policy and allow MSRV bumps in patch releases
+- Use type aliases instead of type defaults to define default `belt-block` implementation ([#112])
+
+[#56]: https://github.com/RustCrypto/block-modes/pull/56
+[#76]: https://github.com/RustCrypto/block-modes/pull/76
+[#112]: https://github.com/RustCrypto/block-modes/pull/112
+
 ## 0.1.0 (2023-04-02)
 - Initial release

--- a/belt-ctr/README.md
+++ b/belt-ctr/README.md
@@ -32,7 +32,7 @@ let ciphertext: &[u8; 34] = &hex!(
     "7D1B"
 );
 
-let mut cipher: BeltCtr = BeltCtr::new_from_slices(key, iv).unwrap();
+let mut cipher = BeltCtr::new_from_slices(key, iv).unwrap();
 
 // encrypt in-place
 let mut buf = plaintext.clone();

--- a/belt-ctr/src/lib.rs
+++ b/belt-ctr/src/lib.rs
@@ -20,13 +20,12 @@ use core::fmt;
 #[cfg(feature = "zeroize")]
 use cipher::zeroize::{Zeroize, ZeroizeOnDrop};
 
-/// Byte-level BelT CTR generic over block cipher implementation
-pub type GenericBeltCtr<C> = StreamCipherCoreWrapper<GenericBeltCtrCore<C>>;
-
 /// Byte-level BelT CTR
 pub type BeltCtr = GenericBeltCtr<BeltBlock>;
 /// Block-level BelT CTR
 pub type BeltCtrCore = GenericBeltCtrCore<BeltBlock>;
+/// Byte-level BelT CTR generic over block cipher implementation
+pub type GenericBeltCtr<C> = StreamCipherCoreWrapper<GenericBeltCtrCore<C>>;
 
 /// Block-level BelT CTR generic over block cipher implementation
 pub struct GenericBeltCtrCore<C>

--- a/belt-ctr/src/lib.rs
+++ b/belt-ctr/src/lib.rs
@@ -20,11 +20,16 @@ use core::fmt;
 #[cfg(feature = "zeroize")]
 use cipher::zeroize::{Zeroize, ZeroizeOnDrop};
 
-/// Byte-level BelT CTR
-pub type BeltCtr<C = BeltBlock> = StreamCipherCoreWrapper<BeltCtrCore<C>>;
+/// Byte-level BelT CTR generic over block cipher implementation
+pub type GenericBeltCtr<C> = StreamCipherCoreWrapper<GenericBeltCtrCore<C>>;
 
+/// Byte-level BelT CTR
+pub type BeltCtr = GenericBeltCtr<BeltBlock>;
 /// Block-level BelT CTR
-pub struct BeltCtrCore<C = BeltBlock>
+pub type BeltCtrCore = GenericBeltCtrCore<BeltBlock>;
+
+/// Block-level BelT CTR generic over block cipher implementation
+pub struct GenericBeltCtrCore<C>
 where
     C: BlockCipherEncrypt + BlockSizeUser<BlockSize = U16>,
 {
@@ -33,7 +38,7 @@ where
     s_init: u128,
 }
 
-impl<C> StreamCipherCore for BeltCtrCore<C>
+impl<C> StreamCipherCore for GenericBeltCtrCore<C>
 where
     C: BlockCipherEncrypt + BlockSizeUser<BlockSize = U16>,
 {
@@ -65,7 +70,7 @@ where
     }
 }
 
-impl<C> StreamCipherSeekCore for BeltCtrCore<C>
+impl<C> StreamCipherSeekCore for GenericBeltCtrCore<C>
 where
     C: BlockCipherEncrypt + BlockSizeUser<BlockSize = U16>,
 {
@@ -80,28 +85,28 @@ where
     }
 }
 
-impl<C> BlockSizeUser for BeltCtrCore<C>
+impl<C> BlockSizeUser for GenericBeltCtrCore<C>
 where
     C: BlockCipherEncrypt + BlockSizeUser<BlockSize = U16>,
 {
     type BlockSize = C::BlockSize;
 }
 
-impl<C> IvSizeUser for BeltCtrCore<C>
+impl<C> IvSizeUser for GenericBeltCtrCore<C>
 where
     C: BlockCipherEncrypt + BlockSizeUser<BlockSize = U16>,
 {
     type IvSize = C::BlockSize;
 }
 
-impl<C> InnerUser for BeltCtrCore<C>
+impl<C> InnerUser for GenericBeltCtrCore<C>
 where
     C: BlockCipherEncrypt + BlockSizeUser<BlockSize = U16>,
 {
     type Inner = C;
 }
 
-impl<C> InnerIvInit for BeltCtrCore<C>
+impl<C> InnerIvInit for GenericBeltCtrCore<C>
 where
     C: BlockCipherEncrypt + BlockSizeUser<BlockSize = U16>,
 {
@@ -118,7 +123,7 @@ where
     }
 }
 
-impl<C> IvState for BeltCtrCore<C>
+impl<C> IvState for GenericBeltCtrCore<C>
 where
     C: BlockCipherEncrypt + BlockCipherDecrypt + BlockSizeUser<BlockSize = U16>,
 {
@@ -129,7 +134,7 @@ where
     }
 }
 
-impl<C> AlgorithmName for BeltCtrCore<C>
+impl<C> AlgorithmName for GenericBeltCtrCore<C>
 where
     C: BlockCipherEncrypt + BlockSizeUser<BlockSize = U16> + AlgorithmName,
 {
@@ -140,7 +145,7 @@ where
     }
 }
 
-impl<C> fmt::Debug for BeltCtrCore<C>
+impl<C> fmt::Debug for GenericBeltCtrCore<C>
 where
     C: BlockCipherEncrypt + BlockSizeUser<BlockSize = U16> + AlgorithmName,
 {
@@ -152,7 +157,7 @@ where
     }
 }
 
-impl<C: BlockCipherEncrypt> Drop for BeltCtrCore<C>
+impl<C: BlockCipherEncrypt> Drop for GenericBeltCtrCore<C>
 where
     C: BlockCipherEncrypt + BlockSizeUser<BlockSize = U16>,
 {
@@ -166,7 +171,7 @@ where
 }
 
 #[cfg(feature = "zeroize")]
-impl<C> ZeroizeOnDrop for BeltCtrCore<C> where
+impl<C> ZeroizeOnDrop for GenericBeltCtrCore<C> where
     C: BlockCipherEncrypt + BlockSizeUser<BlockSize = U16> + ZeroizeOnDrop
 {
 }


### PR DESCRIPTION
Unfortunately, type defaults used previously are not handled well in the current Rust. For example, it could be seen in the readme example where we can not use `let mut cipher = BeltCtr::new_from_slices(key, iv)?;` and instead have to use either `let mut cipher: BeltCtr = BeltCtr::new_from_slices(key, iv)?;` or `<BeltCtr>::new_from_slices`.