### PR TITLE
Release new versions dependent on `cipher` v0.5

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -24,7 +24,7 @@ dependencies = [
 
 [[package]]
 name = "belt-ctr"
-version = "0.2.0-rc.3"
+version = "0.2.0"
 dependencies = [
  "belt-block",
  "cipher",
@@ -58,7 +58,7 @@ dependencies = [
 
 [[package]]
 name = "cbc"
-version = "0.2.0-rc.4"
+version = "0.2.0"
 dependencies = [
  "aes",
  "cipher",
@@ -67,7 +67,7 @@ dependencies = [
 
 [[package]]
 name = "cfb-mode"
-version = "0.9.0-rc.3"
+version = "0.9.0"
 dependencies = [
  "aes",
  "belt-block",
@@ -77,7 +77,7 @@ dependencies = [
 
 [[package]]
 name = "cfb8"
-version = "0.9.0-rc.3"
+version = "0.9.0"
 dependencies = [
  "aes",
  "cipher",
@@ -129,7 +129,7 @@ dependencies = [
 
 [[package]]
 name = "ctr"
-version = "0.10.0-rc.4"
+version = "0.10.0"
 dependencies = [
  "aes",
  "cipher",
@@ -140,7 +140,7 @@ dependencies = [
 
 [[package]]
 name = "cts"
-version = "0.7.0-rc.3"
+version = "0.7.0"
 dependencies = [
  "aes",
  "belt-block",
@@ -166,7 +166,7 @@ dependencies = [
 
 [[package]]
 name = "ige"
-version = "0.2.0-rc.3"
+version = "0.2.0"
 dependencies = [
  "aes",
  "cipher",
@@ -210,7 +210,7 @@ dependencies = [
 
 [[package]]
 name = "ofb"
-version = "0.7.0-rc.3"
+version = "0.7.0"
 dependencies = [
  "aes",
  "cipher",
@@ -219,7 +219,7 @@ dependencies = [
 
 [[package]]
 name = "pcbc"
-version = "0.2.0-rc.3"
+version = "0.2.0"
 dependencies = [
  "aes",
  "cipher",

--- a/belt-ctr/CHANGELOG.md
+++ b/belt-ctr/CHANGELOG.md
@@ -5,7 +5,7 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/)
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
-## 0.2.0 (UNRELEASED)
+## 0.2.0 (2026-04-10)
 ## Added
 - `GenericBeltCtr` and `GenericBeltCtrCore` types ([#112])
 

--- a/belt-ctr/Cargo.toml
+++ b/belt-ctr/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "belt-ctr"
-version = "0.2.0-rc.3"
+version = "0.2.0"
 description = "CTR block mode of operation specified by the BelT standard"
 authors = ["RustCrypto Developers"]
 license = "MIT OR Apache-2.0"

--- a/cbc/CHANGELOG.md
+++ b/cbc/CHANGELOG.md
@@ -5,7 +5,7 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
-## 0.2.0 (UNRELEASED)
+## 0.2.0 (2026-04-10)
 ### Removed 
 - `std` feature ([#76])
 - `Clone` impl ([#91])

--- a/cbc/CHANGELOG.md
+++ b/cbc/CHANGELOG.md
@@ -6,7 +6,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ## 0.2.0 (2026-04-10)
-### Removed 
+### Removed
 - `std` feature ([#76])
 - `Clone` impl ([#91])
 

--- a/cbc/Cargo.toml
+++ b/cbc/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "cbc"
-version = "0.2.0-rc.4"
+version = "0.2.0"
 description = "Cipher Block Chaining (CBC) block cipher mode of operation"
 authors = ["RustCrypto Developers"]
 license = "MIT OR Apache-2.0"

--- a/cfb-mode/CHANGELOG.md
+++ b/cfb-mode/CHANGELOG.md
@@ -5,7 +5,7 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/)
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
-## 0.9.0 (UNRELEASED)
+## 0.9.0 (2026-04-10)
 ### Removed 
 - `std` feature ([#76])
 - `Clone` impl ([#91])

--- a/cfb-mode/CHANGELOG.md
+++ b/cfb-mode/CHANGELOG.md
@@ -6,7 +6,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/)
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ## 0.9.0 (2026-04-10)
-### Removed 
+### Removed
 - `std` feature ([#76])
 - `Clone` impl ([#91])
 

--- a/cfb-mode/Cargo.toml
+++ b/cfb-mode/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "cfb-mode"
-version = "0.9.0-rc.3"
+version = "0.9.0"
 description = "Cipher Feedback (CFB) block cipher mode of operation"
 authors = ["RustCrypto Developers"]
 license = "MIT OR Apache-2.0"

--- a/cfb8/CHANGELOG.md
+++ b/cfb8/CHANGELOG.md
@@ -5,7 +5,7 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/)
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
-## 0.9.0 (UNRELEASED)
+## 0.9.0 (2026-04-10)
 ### Removed 
 - `std` feature ([#76])
 - `Clone` impl ([#91])

--- a/cfb8/CHANGELOG.md
+++ b/cfb8/CHANGELOG.md
@@ -6,7 +6,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/)
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ## 0.9.0 (2026-04-10)
-### Removed 
+### Removed
 - `std` feature ([#76])
 - `Clone` impl ([#91])
 

--- a/cfb8/Cargo.toml
+++ b/cfb8/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "cfb8"
-version = "0.9.0-rc.3"
+version = "0.9.0"
 description = "Cipher Feedback with eight bit feedback (CFB-8) block cipher mode of operation"
 authors = ["RustCrypto Developers"]
 license = "MIT OR Apache-2.0"

--- a/ctr/CHANGELOG.md
+++ b/ctr/CHANGELOG.md
@@ -5,7 +5,7 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/)
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
-## 0.10.0 (UNRELEASED)
+## 0.10.0 (2026-04-10)
 ### Removed 
 - `std` feature ([#76])
 - `Clone` impl ([#91])

--- a/ctr/CHANGELOG.md
+++ b/ctr/CHANGELOG.md
@@ -6,7 +6,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/)
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ## 0.10.0 (2026-04-10)
-### Removed 
+### Removed
 - `std` feature ([#76])
 - `Clone` impl ([#91])
 

--- a/ctr/Cargo.toml
+++ b/ctr/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "ctr"
-version = "0.10.0-rc.4"
+version = "0.10.0"
 description = "CTR block modes of operation"
 authors = ["RustCrypto Developers"]
 license = "MIT OR Apache-2.0"

--- a/cts/CHANGELOG.md
+++ b/cts/CHANGELOG.md
@@ -6,7 +6,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ## 0.7.0 (2026-04-10)
-### Removed 
+### Removed
 - `std` feature ([#76])
 - `Clone` impl ([#91])
 

--- a/cts/CHANGELOG.md
+++ b/cts/CHANGELOG.md
@@ -5,7 +5,7 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
-## 0.7.0 (UNRELEASED)
+## 0.7.0 (2026-04-10)
 ### Removed 
 - `std` feature ([#76])
 - `Clone` impl ([#91])

--- a/cts/Cargo.toml
+++ b/cts/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "cts"
-version = "0.7.0-rc.3"
+version = "0.7.0"
 description = "Generic implementation of the ciphertext stealing block modes of operation"
 authors = ["RustCrypto Developers"]
 license = "MIT OR Apache-2.0"

--- a/ige/CHANGELOG.md
+++ b/ige/CHANGELOG.md
@@ -5,7 +5,7 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
-## 0.2.0 (UNRELEASED)
+## 0.2.0 (2026-04-10)
 ### Removed 
 - `std` feature ([#76])
 - `Clone` impl ([#91])

--- a/ige/CHANGELOG.md
+++ b/ige/CHANGELOG.md
@@ -6,7 +6,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ## 0.2.0 (2026-04-10)
-### Removed 
+### Removed
 - `std` feature ([#76])
 - `Clone` impl ([#91])
 

--- a/ige/Cargo.toml
+++ b/ige/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "ige"
-version = "0.2.0-rc.3"
+version = "0.2.0"
 description = "Infinite Garble Extension (IGE) block cipher mode of operation"
 authors = ["RustCrypto Developers"]
 license = "MIT OR Apache-2.0"

--- a/ofb/CHANGELOG.md
+++ b/ofb/CHANGELOG.md
@@ -6,7 +6,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/)
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ## 0.7.0 (2026-04-10)
-### Removed 
+### Removed
 - `std` feature ([#76])
 - `Clone` impl ([#91])
 

--- a/ofb/CHANGELOG.md
+++ b/ofb/CHANGELOG.md
@@ -5,7 +5,7 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/)
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
-## 0.7.0 (UNRELEASED)
+## 0.7.0 (2026-04-10)
 ### Removed 
 - `std` feature ([#76])
 - `Clone` impl ([#91])

--- a/ofb/Cargo.toml
+++ b/ofb/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "ofb"
-version = "0.7.0-rc.3"
+version = "0.7.0"
 description = "Output Feedback (OFB) block cipher mode of operation"
 authors = ["RustCrypto Developers"]
 license = "MIT OR Apache-2.0"

--- a/pcbc/CHANGELOG.md
+++ b/pcbc/CHANGELOG.md
@@ -5,7 +5,7 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
-## 0.2.0 (UNRELEASED)
+## 0.2.0 (2026-04-10)
 ### Removed 
 - `std` feature ([#76])
 - `Clone` impl ([#91])

--- a/pcbc/CHANGELOG.md
+++ b/pcbc/CHANGELOG.md
@@ -6,7 +6,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ## 0.2.0 (2026-04-10)
-### Removed 
+### Removed
 - `std` feature ([#76])
 - `Clone` impl ([#91])
 

--- a/pcbc/Cargo.toml
+++ b/pcbc/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "pcbc"
-version = "0.2.0-rc.3"
+version = "0.2.0"
 description = "Propagating Cipher Block Chaining (PCBC) block cipher mode of operation"
 authors = ["RustCrypto Developers"]
 license = "MIT OR Apache-2.0"


### PR DESCRIPTION
Most crates contain the following changelog:

### Removed 
- `std` feature ([#76])
- `Clone` impl ([#91])

### Changed
- Bump `cipher` from `0.4` to `0.5` ([#56])
- Edition changed to 2024 and MSRV bumped to 1.85 ([#76])
- Relax MSRV policy and allow MSRV bumps in patch releases

[#56]: https://github.com/RustCrypto/block-modes/pull/56
[#76]: https://github.com/RustCrypto/block-modes/pull/76
[#91]: https://github.com/RustCrypto/block-modes/pull/91