### PR TITLE
Remove `gost-modes` from the algorithms table

### DIFF
--- a/README.md
+++ b/README.md
@@ -17,7 +17,7 @@ less error-prone than manual integrity verification.
 
 **USE AT YOUR OWN RISK!**
 
-## Supported algorithms
+## Supported Algorithms
 
 | Name | Crate name | crates.io |  Docs  | MSRV |
 |------|------------|:---------:|:------:|:----:|
@@ -27,14 +27,9 @@ less error-prone than manual integrity verification.
 | [Full-block Cipher Feedback][CFB] | [`cfb-mode`] | [![crates.io](https://img.shields.io/crates/v/cfb-mode.svg)](https://crates.io/crates/cfb-mode) | [![Documentation](https://docs.rs/cfb-mode/badge.svg)](https://docs.rs/cfb-mode) |  ![MSRV 1.85][msrv-1.85] |
 | [Counter][CTR] | [`ctr`] | [![crates.io](https://img.shields.io/crates/v/ctr.svg)](https://crates.io/crates/ctr) | [![Documentation](https://docs.rs/ctr/badge.svg)](https://docs.rs/ctr) |  ![MSRV 1.85][msrv-1.85] |
 | [Ciphertext stealing][CTS] | [`cts`] | [![crates.io](https://img.shields.io/crates/v/cts.svg)](https://crates.io/crates/cts) | [![Documentation](https://docs.rs/cts/badge.svg)](https://docs.rs/cts) |  ![MSRV 1.85][msrv-1.85] |
-| [GOST R 34.13-2015] | [`gost-modes`] | [![crates.io](https://img.shields.io/crates/v/gost-modes.svg)](https://crates.io/crates/gost-modes) | [![Documentation](https://docs.rs/gost-modes/badge.svg)](https://docs.rs/gost-modes) | ![MSRV 1.85][msrv-1.85] |
 | [Infinite Garble Extension][IGE] | [`ige`] | [![crates.io](https://img.shields.io/crates/v/ige.svg)](https://crates.io/crates/ige) | [![Documentation](https://docs.rs/ige/badge.svg)](https://docs.rs/ige) |  ![MSRV 1.85][msrv-1.85] |
 | [Output Feedback][OFB] | [`ofb`] | [![crates.io](https://img.shields.io/crates/v/ofb.svg)](https://crates.io/crates/ofb) | [![Documentation](https://docs.rs/ofb/badge.svg)](https://docs.rs/ofb) |  ![MSRV 1.85][msrv-1.85] |
 | [Propagating Cipher Block Chaining][PCBC] | [`pcbc`] | [![crates.io](https://img.shields.io/crates/v/pcbc.svg)](https://crates.io/crates/pcbc) | [![Documentation](https://docs.rs/pcbc/badge.svg)](https://docs.rs/pcbc) |  ![MSRV 1.85][msrv-1.85] |
-
-### Minimum Supported Rust Version (MSRV) Policy
-
-MSRV bumps are considered breaking changes and will be performed only with minor version bump.
 
 ## License
 


### PR DESCRIPTION
Additionally removes the MSRV policy section.